### PR TITLE
Make lockBodyScroll optional in Modal

### DIFF
--- a/packages/components/components/elvis-modal/package.json
+++ b/packages/components/components/elvis-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-modal",
-  "version": "0.0.1-beta.7",
+  "version": "0.0.1-beta.8",
   "description": "",
   "license": "MIT",
   "author": "",

--- a/packages/components/components/elvis-modal/src/react/elvia-modal.tsx
+++ b/packages/components/components/elvis-modal/src/react/elvia-modal.tsx
@@ -14,6 +14,7 @@ export interface ModalProps {
   secondaryButton?: HTMLElement;
   className?: string;
   hasCloseBtn?: boolean;
+  hasLockBodyScroll?: boolean;
   onHide: () => void;
   webcomponent?: any;
 }
@@ -27,6 +28,7 @@ export const ModalComponent: FC<ModalProps> = ({
   secondaryButton,
   className,
   hasCloseBtn = false,
+  hasLockBodyScroll = true,
   onHide,
   webcomponent,
 }) => {
@@ -51,7 +53,7 @@ export const ModalComponent: FC<ModalProps> = ({
 
   useClickOutside(modalWrapperRef, () => isShowing && handleOnHide());
   useKeyPress('Escape', handleOnHide);
-  useLockBodyScroll(isShowing);
+  hasLockBodyScroll && useLockBodyScroll(isShowing);
   useFocusTrap(modalWrapperRef);
 
   useEffect(() => {

--- a/packages/components/elvia-components.config.js
+++ b/packages/components/elvia-components.config.js
@@ -162,7 +162,8 @@ module.exports = [
       { name: 'primaryButton', type: 'HTMLElement' },
       { name: 'secondaryButton', type: 'HTMLElement' },
       { name: 'className', type: 'string' },
-      { name: 'hasCloseBtn', type: 'boolean' }
+      { name: 'hasCloseBtn', type: 'boolean' },
+      { name: 'hasLockBodyScroll', type: 'boolean' }
     ],
     reactName: 'Modal',
     slotItems: true

--- a/packages/components/frameworks/react-ssr/package.json
+++ b/packages/components/frameworks/react-ssr/package.json
@@ -10,7 +10,7 @@
     "@elvia/elvis-checkbox": "*",
     "@elvia/elvis-datepicker": "*",
     "@elvia/elvis-dropdown": "*",
-    "@elvia/elvis-modal": "0.0.1-beta.6",
+    "@elvia/elvis-modal": "0.0.1-beta.8",
     "@elvia/elvis-popover": "*",
     "@elvia/elvis-progress-linear": "*",
     "@elvia/elvis-tabs": "*",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,7 +29,7 @@
     "@elvia/elvis-accordion": "*",
     "@elvia/elvis-assets-icons": "*",
     "@elvia/elvis-dropdown": "*",
-    "@elvia/elvis-modal": "0.0.1-beta.6",
+    "@elvia/elvis-modal": "0.0.1-beta.8",
     "@elvia/elvis-popover": "*",
     "@elvia/elvis-box": "0.0.1-beta.1",
     "@elvia/elvis-progress-linear": "*",


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
When using the modal for the onboarding/tutorial component we found it necessary to turn off lock body scroll in the modal because we wanted it to be locked for both the modal and the highlighting overlay. Having lock body scroll implemented on the modal and the highlighting feature separately made things buggy, so we decided maybe we could have the lockBodyScroll as optional in the modal but by default it is turned on. 