### PR TITLE
Eslint: ignoring frameworks when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ packages/elvis/elvis.js
 packages/elvis/src/templates/elvis.template.js
 packages/elvis/icons.js
 packages/elvis/icons.d.ts
+packages/components/frameworks/*


### PR DESCRIPTION
* ignoring frameworks when running eslint to fix bug 