### PR TITLE
Popover: use display none to remove white space

### DIFF
--- a/packages/components/components/elvis-popover/CHANGELOG.md
+++ b/packages/components/components/elvis-popover/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Elvia Popover Changelog
 
+## 4.1.3 (16.09.21)
+
+### Bug fixes
+
+- Use display: none instead of visibility: hidden to remove white space created by the popover in application
+  due to SSR.
+
 ## 4.1.2 (9.08.21)
 
 ### Bug fixes

--- a/packages/components/components/elvis-popover/package.json
+++ b/packages/components/components/elvis-popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-popover",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "",
   "license": "MIT",
   "author": "",

--- a/packages/components/components/elvis-popover/src/react/style.scss
+++ b/packages/components/components/elvis-popover/src/react/style.scss
@@ -52,6 +52,18 @@ $green: #29d305;
     }
   }
 
+  @keyframes fadeIn {
+    0% {
+      opacity: 0;
+    }
+    1% {
+      display: block;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
   &__content {
     display: flex;
     flex-direction: column;
@@ -68,7 +80,7 @@ $green: #29d305;
     text-align: left;
     box-shadow: $popover-box-shadow;
     border-radius: 8px;
-    transition: opacity 250ms ease-in;
+    animation: fadeIn 250ms ease-in;
     // Top aligned
     bottom: 100%;
     margin-bottom: 16px;
@@ -98,10 +110,10 @@ $green: #29d305;
   &.ewc-popover--hide .ewc-popover__content,
   &.ewc-popover--hide .ewc-popover__backdrop {
     opacity: 0;
-    visibility: hidden;
+    display: none;
     .ewc-btn .ewc-btn__icon i {
       opacity: 0;
-      visibility: hidden;
+      display: none;
     }
   }
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
Because popover content used visibility: hidden it created a white space in applications with SSR. Changing it to display: none and updating the animation solved the problem.

Video of the problem at Elvia.no
https://user-images.githubusercontent.com/50363113/133605327-5730ffef-260e-4f29-934d-6c7569dd74a8.mov