### PR TITLE
Modal: escape key now only closes modal, not open

### DIFF
--- a/packages/components/components/elvis-modal/CHANGELOG.md
+++ b/packages/components/components/elvis-modal/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Elvia Modal Changelog
 
+## 1.2.2 (12.11.21)
+
+### Bug fix
+
+- Fixed escape keypress opening modal.
 ## 1.2.0 (05.11.21)
 
 ### New features

--- a/packages/components/components/elvis-modal/package.json
+++ b/packages/components/components/elvis-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-modal",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "license": "MIT",
   "author": "",

--- a/packages/components/components/elvis-modal/src/react/elvia-modal.tsx
+++ b/packages/components/components/elvis-modal/src/react/elvia-modal.tsx
@@ -46,6 +46,9 @@ export const ModalComponent: FC<ModalProps> = ({
   const hasSecondaryButton = !!secondaryButton || (webcomponent && !!webcomponent.getSlot('secondaryButton'));
 
   const handleOnHide = () => {
+    if (!isShowing) {
+      return;
+    }
     if (disableClose) {
       return;
     }


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
https://elvia.atlassian.net/jira/software/c/projects/LEGO/boards/60?modal=detail&selectedIssue=LEGO-1275

Jeg merket også noe rar oppførsel fra modal dersom det er flere modal på en side, men det ble også fikset av dette (uten at jeg så nærmere på det)