### PR TITLE
added ignore command to netlify preview builds of dependabot commits

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,6 @@
 [build]
     functions = "functions"
+    
+[context.deploy-preview]
     # ignore all PRs opened by `dependabot` (with last commit made by `dependabot`)
     ignore = 'git log -1 --pretty=%B | grep dependabot'


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
netlify bygger ikke preview ved PR(commits) fra dependabot eller renovatebot, ref oppg: https://elvia.atlassian.net/jira/software/c/projects/LEGO/boards/60?modal=detail&selectedIssue=LEGO-1316&assignee=5f439134fdc3f5003fdfa8f2