### PR TITLE
Lego 1543: upgrade typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.7",
     "tslint": "~6.1.0",
-    "typescript": "~4.0.2",
+    "typescript": "~4.6.2",
     "@vue/cli-service": "4.5.13",
     "@vue/cli-plugin-eslint": "~5.0.0-rc.1",
     "rxjs": "^6.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19691,15 +19691,10 @@ typescript-plugin-styled-components@^2.0.0:
   resolved "https://registry.yarnpkg.com/typescript-plugin-styled-components/-/typescript-plugin-styled-components-2.0.0.tgz#97e94187cca0f3058c6ad8fefffbca6766c56123"
   integrity sha512-Wu7F96dwuphgiACHfu63vTbRRg6tkPwLnpFJwdxM70Y0PLfeKLRnvs2Yo5MAySMwE120ODMKk9W4TtJgY1ZumA==
 
-typescript@^4.0.2:
+typescript@^4.0.2, typescript@~4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
-
-typescript@~4.0.2:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.8.tgz#5739105541db80a971fdbd0d56511d1a6f17d37f"
-  integrity sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==
 
 typescript@~4.5.5:
   version "4.5.5"


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
https://elvia.atlassian.net/jira/software/c/projects/LEGO/boards/60?modal=detail&selectedIssue=LEGO-1543
Upgrade Typescript to 4.6 in the root package.json. Web has its own version defined (for Angular).