### PR TITLE
Lego 1580: fix datepicker minDate/maxDate null

### DIFF
--- a/packages/components/components/elvis-datepicker/CHANGELOG.json
+++ b/packages/components/components/elvis-datepicker/CHANGELOG.json
@@ -2,8 +2,20 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "07.04.22",
+      "version": "2.8.5 ",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed an issue where sending null as minDate or maxDate to the datepicker caused unexpected behaviour. "
+          ]
+        }
+      ]
+    },
+    {
       "date": "04.04.22",
-      "version": "2.8.3 ",
+      "version": "2.8.4 ",
       "changelog": [
         {
           "type": "patch",

--- a/packages/components/components/elvis-datepicker/package.json
+++ b/packages/components/components/elvis-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-datepicker",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "",
   "main": "web_component.js",
   "scripts": {

--- a/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.tsx
+++ b/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.tsx
@@ -431,8 +431,8 @@ export const Datepicker: FC<DatepickerProps> = ({
             rifmFormatter={getDateFormat}
             disabled={isDisabled === true}
             fullWidth={isFullWidth === true}
-            minDate={minDate}
-            maxDate={maxDate}
+            minDate={minDate ? minDate : undefined}
+            maxDate={maxDate ? maxDate : undefined}
             onChange={handleDateChange}
             onFocus={onFocus}
             open={isDatepickerOpen}

--- a/packages/web/src/assets/changelogs/elvis-datepicker/CHANGELOG.json
+++ b/packages/web/src/assets/changelogs/elvis-datepicker/CHANGELOG.json
@@ -2,8 +2,20 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "07.04.22",
+      "version": "2.8.5 ",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed an issue where sending null as minDate or maxDate to the datepicker caused unexpected behaviour. "
+          ]
+        }
+      ]
+    },
+    {
       "date": "04.04.22",
-      "version": "2.8.3 ",
+      "version": "2.8.4 ",
       "changelog": [
         {
           "type": "patch",


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
https://elvia.atlassian.net/jira/software/c/projects/LEGO/boards/60?modal=detail&selectedIssue=LEGO-1580

For meg forsvant ikke innholdet i datepickeren om minDate/maxDate var null, men det var ikke mulig å bytte måned når en av de var null. Det funker nå iallfall 😅 
Så også at versjon 2.8.3 har blitt skippet her, haha