### PR TITLE
Set Netlify YARN default version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build]
     functions = "functions"
-    
+
+[build.environment]
+    YARN_VERSION = "3.2.0"
+
 [context.deploy-preview]
     # ignore all PRs opened by `dependabot` (with last commit made by `dependabot`)
     ignore = 'git log -1 --pretty=%B | grep dependabot'


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

## Describe PR briefly:
Gjør sånn at Netlify ikke laster ned gammel versjon av Yarn (1.22.4) på hver deploy selv om den ikke skal bruke det.