### PR TITLE
Lego 1926: Remove unused material dependencies, fix spotlight interface

### DIFF
--- a/packages/components/components/elvis-carousel/CHANGELOG.json
+++ b/packages/components/components/elvis-carousel/CHANGELOG.json
@@ -2,6 +2,16 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "07.10.22",
+      "version": "2.1.4",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": ["Removed unused dependencies."]
+        }
+      ]
+    },
+    {
       "date": "28.09.22",
       "version": "2.1.3",
       "changelog": [

--- a/packages/components/components/elvis-carousel/package.json
+++ b/packages/components/components/elvis-carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-carousel",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "",
   "license": "MIT",
   "author": "",
@@ -11,8 +11,6 @@
     "@elvia/elvis-icon": "^1.3.1",
     "@elvia/elvis-toolbox": "^4.0.0",
     "@elvia/elvis-typography": "^2.2.0",
-    "@material-ui/core": "^4.12.3",
-    "@material-ui/icons": "^4.11.2",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/packages/components/components/elvis-modal/CHANGELOG.json
+++ b/packages/components/components/elvis-modal/CHANGELOG.json
@@ -3,6 +3,16 @@
   "content": [
     {
       "date": "07.10.22",
+      "version": "2.1.9",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": ["Removed unused dependencies."]
+        }
+      ]
+    },
+    {
+      "date": "07.10.22",
       "version": "2.1.8",
       "changelog": [
         {

--- a/packages/components/components/elvis-modal/package.json
+++ b/packages/components/components/elvis-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-modal",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "",
   "license": "MIT",
   "author": "",
@@ -11,8 +11,6 @@
     "@elvia/elvis-icon": "^1.3.0",
     "@elvia/elvis-toolbox": "^4.0.1",
     "@elvia/elvis-typography": "^2.1.0",
-    "@material-ui/core": "^4.12.3",
-    "@material-ui/icons": "^4.11.2",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/packages/components/components/elvis-spotlight/CHANGELOG.json
+++ b/packages/components/components/elvis-spotlight/CHANGELOG.json
@@ -2,6 +2,16 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "07.10.22",
+      "version": "1.4.1",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": ["Fixed a property in the component's interface not being correctly marked as optional."]
+        }
+      ]
+    },
+    {
       "date": "05.10.22",
       "version": "1.4.0",
       "changelog": [

--- a/packages/components/components/elvis-spotlight/package.json
+++ b/packages/components/components/elvis-spotlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-spotlight",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "main": "web_component.js",
   "author": "",

--- a/packages/components/components/elvis-spotlight/src/react/elvia-spotlight.tsx
+++ b/packages/components/components/elvis-spotlight/src/react/elvia-spotlight.tsx
@@ -17,7 +17,7 @@ export interface SpotlightRectangleProps {
 
 export interface SpotlightProps {
   position: SpotlightPosition | undefined;
-  shape: SpotlightShape;
+  shape?: SpotlightShape;
   radius?: number;
   rectangleProps?: SpotlightRectangleProps;
   hasLockBodyScroll?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,8 +2525,6 @@ __metadata:
     "@elvia/elvis-icon": ^1.3.1
     "@elvia/elvis-toolbox": ^4.0.0
     "@elvia/elvis-typography": ^2.2.0
-    "@material-ui/core": ^4.12.3
-    "@material-ui/icons": ^4.11.2
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     react-is: ">= 16.8.0"
@@ -2547,8 +2545,6 @@ __metadata:
     "@elvia/elvis-icon": ^1.3.1
     "@elvia/elvis-toolbox": ^4.0.0
     "@elvia/elvis-typography": ^2.2.0
-    "@material-ui/core": ^4.12.3
-    "@material-ui/icons": ^4.11.2
     styled-components: ^5.3.3
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -2902,8 +2898,6 @@ __metadata:
     "@elvia/elvis-icon": ^1.3.0
     "@elvia/elvis-toolbox": ^4.0.1
     "@elvia/elvis-typography": ^2.1.0
-    "@material-ui/core": ^4.12.3
-    "@material-ui/icons": ^4.11.2
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     react-is: ">= 16.8.0"
@@ -2924,8 +2918,6 @@ __metadata:
     "@elvia/elvis-icon": ^1.3.0
     "@elvia/elvis-toolbox": ^4.0.1
     "@elvia/elvis-typography": ^2.1.0
-    "@material-ui/core": ^4.12.3
-    "@material-ui/icons": ^4.11.2
     styled-components: ^5.3.3
   peerDependencies:
     react: ^16.8.0 || ^17.0.0


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-1926
Fikset også at spotlight sin interface hadde en prop som ikke var markert som optional selv om den har en default verdi.