### PR TITLE
Lego 2224: Add "breaking changes" to missing changelogs

### DIFF
--- a/packages/components/components/elvis-breadcrumb/CHANGELOG.json
+++ b/packages/components/components/elvis-breadcrumb/CHANGELOG.json
@@ -137,8 +137,8 @@
             "Renamed props for more consistent naming conventions. Changed BreadcrumbLink structure. "
           ],
           "fixes": [
-            "Change prop: <span class=\"code-text\">breadcrumbs</span> => <span class=\"code-text\">items</span>",
-            "Change event: <span class=\"code-text\">breadcrumbsOnChange</span> => <span class=\"code-text\">onLinkClick</span>",
+            "Change prop: <span class=\"code-text\">breadcrumbs</span> to <span class=\"code-text\">items</span>",
+            "Change event: <span class=\"code-text\">breadcrumbsOnChange</span> to <span class=\"code-text\">onLinkClick</span>",
             "Change the link items to {'href': '...', 'text': '...'}"
           ]
         }

--- a/packages/components/components/elvis-carousel/CHANGELOG.json
+++ b/packages/components/components/elvis-carousel/CHANGELOG.json
@@ -194,12 +194,12 @@
           "type": "breaking_changes",
           "changes": ["Renamed props and callback functions. Structure for items in carousel has changed."],
           "fixes": [
-            "Rename prop: <span class=\"code-text\">elements</span> => <span class=\"code-text\">items</span>",
-            "New carousel-item structure in React: <span class=\"code-text\">{title: \"\", element: \"\"}</span> => <span class=\"code-text\">{heading: \"\", item: \"\"}</span>",
+            "Rename prop: <span class=\"code-text\">elements</span> to <span class=\"code-text\">items</span>",
+            "New carousel-item structure in React: <span class=\"code-text\">{title: \"\", element: \"\"}</span> to <span class=\"code-text\">{heading: \"\", item: \"\"}</span>",
             "New carousel-item slot-names in Web Component: Name the slots \"item-1\", \"heading-1\", \"item-2\", \"heading-2\" and so on.",
-            "Rename prop: <span class=\"code-text\">hideArrows</span> => <span class=\"code-text\">loop</span>. Make sure to invert the boolean.",
-            "Rename prop: <span class=\"code-text\">useOnboardingCheckmark</span> => <span class=\"code-text\">hasConfirmationCheckmark</span>",
-            "Rename prop: <span class=\"code-text\">onHide</span> => <span class=\"code-text\">onFinish</span>"
+            "Rename prop: <span class=\"code-text\">hideArrows</span> to <span class=\"code-text\">loop</span>. Make sure to invert the boolean.",
+            "Rename prop: <span class=\"code-text\">useOnboardingCheckmark</span> to <span class=\"code-text\">hasConfirmationCheckmark</span>",
+            "Rename prop: <span class=\"code-text\">onHide</span> to <span class=\"code-text\">onFinish</span>"
           ]
         }
       ]

--- a/packages/components/components/elvis-chip/CHANGELOG.json
+++ b/packages/components/components/elvis-chip/CHANGELOG.json
@@ -160,8 +160,8 @@
           ],
           "fixes": [
             "The event <span class=\"code-text\">valueOnChange</span> is replaced by <span class=\"code-text\">isSelectedOnChange</span>. The old event contained both <span class=\"code-text\">value</span> and <span class=\"code-text\">isSelected</span>, but the new event only contains <span class=\"code-text\">isSelected</span>. For webcomponents, the <span class=\"code-text\">value</span> can be accessed through <span class=\"code-text\">$event.target.value</span>.",
-            "Rename prop: <span class=\"code-text\">selected</span> => <span class=\"code-text\">isSelected</span>.",
-            "Rename prop: <span class=\"code-text\">disabled</span> => <span class=\"code-text\">isDisabled</span>."
+            "Rename prop: <span class=\"code-text\">selected</span> to <span class=\"code-text\">isSelected</span>.",
+            "Rename prop: <span class=\"code-text\">disabled</span> to <span class=\"code-text\">isDisabled</span>."
           ]
         },
         {

--- a/packages/components/components/elvis-component-wrapper/CHANGELOG.json
+++ b/packages/components/components/elvis-component-wrapper/CHANGELOG.json
@@ -6,7 +6,7 @@
       "version": "4.0.0",
       "changelog": [
         {
-          "type": "new_feature",
+          "type": "breaking_changes",
           "changes": ["The component config has been moved into each component."]
         }
       ]

--- a/packages/components/components/elvis-datepicker/CHANGELOG.json
+++ b/packages/components/components/elvis-datepicker/CHANGELOG.json
@@ -579,7 +579,7 @@
         {
           "type": "new_feature",
           "changes": [
-            "Added disableDate prop that allows disabling specific dates by sending in a function of the shape  `(day: Date) => boolean` that is true for dates that should be disabled."
+            "Added disableDate prop that allows disabling specific dates by sending in a function that returns true for dates that should be disabled."
           ]
         },
         {
@@ -752,7 +752,7 @@
       "version": "2.0.0 ",
       "changelog": [
         {
-          "type": "new_feature",
+          "type": "breaking_changes",
           "changes": ["Now sending events when no date, or invalid date, is selected"]
         }
       ]

--- a/packages/components/components/elvis-dropdown/CHANGELOG.json
+++ b/packages/components/components/elvis-dropdown/CHANGELOG.json
@@ -19,7 +19,7 @@
       "version": "6.0.0",
       "changelog": [
         {
-          "type": "new_feature",
+          "type": "breaking_changes",
           "changes": [
             "Added the <span class=\"code-text\">errorOptions</span> object which introduces the props <span class=\"code-text\">errorOptions.hasErrorPlaceholder</span> option to the <span class=\"code-text\">errorOptions</span> can be set to false to remove the padding under the form field, <span class=\"code-text\">errorOptions.isErrorState</span> that sets the dropdown i an errorState, and <span class=\"code-text\">errorOptions.text</span> that replaces <span class=\"code-text\">errorMessage</span>."
           ],
@@ -481,8 +481,8 @@
           "type": "breaking_changes",
           "changes": ["Renamed props for more consistent naming conventions."],
           "fixes": [
-            "Change prop: <span class=\"code-text\">options</span> => <span class=\"code-text\">items</span>",
-            "Change prop: <span class=\"code-text\">defaultValue</span> => <span class=\"code-text\">value</span>"
+            "Change prop: <span class=\"code-text\">options</span> to <span class=\"code-text\">items</span>",
+            "Change prop: <span class=\"code-text\">defaultValue</span> to <span class=\"code-text\">value</span>"
           ]
         }
       ]

--- a/packages/components/components/elvis-modal/CHANGELOG.json
+++ b/packages/components/components/elvis-modal/CHANGELOG.json
@@ -227,9 +227,9 @@
           "type": "breaking_changes",
           "changes": ["Renamed several props for more consistent naming conventions. "],
           "fixes": [
-            "Change prop <span class=\"code-text\">title</span> => <span class=\"code-text\">heading</span>.",
-            "Change prop <span class=\"code-text\">hasCloseBtn</span> => <span class=\"code-text\">hasCloseButton</span>.",
-            "Change event listener / callback function <span class=\"code-text\">onHide</span> => <span class=\"code-text\">onClose</span>."
+            "Change prop <span class=\"code-text\">title</span> to <span class=\"code-text\">heading</span>.",
+            "Change prop <span class=\"code-text\">hasCloseBtn</span> to <span class=\"code-text\">hasCloseButton</span>.",
+            "Change event listener / callback function <span class=\"code-text\">onHide</span> to <span class=\"code-text\">onClose</span>."
           ]
         }
       ]

--- a/packages/components/components/elvis-pagination/CHANGELOG.json
+++ b/packages/components/components/elvis-pagination/CHANGELOG.json
@@ -236,11 +236,11 @@
           "type": "breaking_changes",
           "changes": ["Renamed several props for more consistent naming conventions. "],
           "fixes": [
-            "Change prop <span class=\"code-text\">dropdownMenuPos</span> => <span class=\"code-text\">dropdownMenuPosition</span>.",
-            "Change prop <span class=\"code-text\">selectedDropdownItemIndex</span> => <span class=\"code-text\">dropdownSelectedItemIndex</span>.",
-            "Change event <span class=\"code-text\">selectedDropdownItemIndexOnChange</span> => <span class=\"code-text\">dropdownSelectedItemIndexOnChange</span>.",
+            "Change prop <span class=\"code-text\">dropdownMenuPos</span> to <span class=\"code-text\">dropdownMenuPosition</span>.",
+            "Change prop <span class=\"code-text\">selectedDropdownItemIndex</span> to <span class=\"code-text\">dropdownSelectedItemIndex</span>.",
+            "Change event <span class=\"code-text\">selectedDropdownItemIndexOnChange</span> to <span class=\"code-text\">dropdownSelectedItemIndexOnChange</span>.",
             "Combine the props <span class=\"code-text\">labelDisplaying</span>, <span class=\"code-text\">labelOf</span>, and <span class=\"code-text\">label</span> into the new <span class=\"code-text\">labelOptions</span> prop.",
-            "Change prop <span class=\"code-text\">isRightAligned</span> => <span class=\"code-text\">alignment</span>. No longer a boolean, but instead either <span class=\"code-text\">'left'</span> or <span class=\"code-text\">'right'</span>. "
+            "Change prop <span class=\"code-text\">isRightAligned</span> to <span class=\"code-text\">alignment</span>. No longer a boolean, but instead either <span class=\"code-text\">'left'</span> or <span class=\"code-text\">'right'</span>. "
           ]
         }
       ]

--- a/packages/components/components/elvis-popover/CHANGELOG.json
+++ b/packages/components/components/elvis-popover/CHANGELOG.json
@@ -320,12 +320,12 @@
           "type": "breaking_changes",
           "changes": ["Renamed several props for more consistent naming conventions. "],
           "fixes": [
-            "Change prop <span class=\"code-text\">hasCloseBtn</span> => <span class=\"code-text\">hasCloseButton</span>.",
-            "Change prop <span class=\"code-text\">header</span> => <span class=\"code-text\">heading</span>.",
-            "Change prop <span class=\"code-text\">posX</span> => <span class=\"code-text\">horizontalPosition</span>.",
-            "Change prop <span class=\"code-text\">posY</span> => <span class=\"code-text\">verticalPosition</span>.",
-            "Change prop <span class=\"code-text\">selectable</span> => <span class=\"code-text\">isSelectable</span>.",
-            "Change prop <span class=\"code-text\">isShowingOnChange</span> => <span class=\"code-text\">onOpen</span> & <span class=\"code-text\">onClose</span>."
+            "Change prop <span class=\"code-text\">hasCloseBtn</span> to <span class=\"code-text\">hasCloseButton</span>.",
+            "Change prop <span class=\"code-text\">header</span> to <span class=\"code-text\">heading</span>.",
+            "Change prop <span class=\"code-text\">posX</span> to <span class=\"code-text\">horizontalPosition</span>.",
+            "Change prop <span class=\"code-text\">posY</span> to <span class=\"code-text\">verticalPosition</span>.",
+            "Change prop <span class=\"code-text\">selectable</span> to <span class=\"code-text\">isSelectable</span>.",
+            "Change prop <span class=\"code-text\">isShowingOnChange</span> to <span class=\"code-text\">onOpen</span> & <span class=\"code-text\">onClose</span>."
           ]
         }
       ]
@@ -576,9 +576,9 @@
       "version": "3.0.0 ",
       "changelog": [
         {
-          "type": "bug_fix",
+          "type": "breaking_changes",
           "changes": [
-            "Trigger now only takes up the space of it's content and the popover is now displayed as block and not  inline-block!"
+            "Trigger now only takes up the space of it's content and the popover is now displayed as block and not inline-block!"
           ]
         }
       ]
@@ -601,7 +601,7 @@
       "version": "2.0.0 ",
       "changelog": [
         {
-          "type": "bug_fix",
+          "type": "breaking_changes",
           "changes": ["Popover safari box-sizing bug", "Popover without shadow dom"]
         }
       ]

--- a/packages/components/components/elvis-progress-linear/CHANGELOG.json
+++ b/packages/components/components/elvis-progress-linear/CHANGELOG.json
@@ -65,8 +65,8 @@
           "type": "breaking_changes",
           "changes": [
             "Removed bottom margin for the progressbar. Now it has no margin, which means spacing must be added manually.",
-            "The sizes have been rearranged to open up for possible new sizes in the future. Medium -> Small and Large -> Medium.",
-            "SCSS -> StyledComponents"
+            "The sizes have been rearranged to open up for possible new sizes in the future. Medium to Small and Large to Medium.",
+            "SCSS to StyledComponents"
           ],
           "fixes": [
             "If you want the same margin as previously, use <span class=\"code-text\">margin-bottom: 40px</span>",

--- a/packages/components/components/elvis-toolbox/CHANGELOG.json
+++ b/packages/components/components/elvis-toolbox/CHANGELOG.json
@@ -125,7 +125,7 @@
       "version": "7.0.0",
       "changelog": [
         {
-          "type": "patch",
+          "type": "breaking_changes",
           "changes": ["Deprecated warning function refactored and component config types added."]
         }
       ]

--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -905,8 +905,8 @@
         {
           "type": "breaking_changes",
           "changes": [
-            "Segmented controls are now in three sizes: <br />Small -> Medium <br />Medium -> Large <br />New Small size (smaller than the previous) <br />",
-            "Title xs on mobiles has been updated font-size from 18px -> 16px. This is done so that the difference between title sm and xs i more distinct.",
+            "Segmented controls are now in three sizes: <br />Small to Medium <br />Medium to Large <br />New Small size (smaller than the previous) <br />",
+            "Title xs on mobiles has been updated font-size from 18px to 16px. This is done so that the difference between title sm and xs i more distinct.",
             "Toggle has updated structure and now includes label and role. This is done for better accessibility."
           ],
           "fixes": [
@@ -1315,7 +1315,7 @@
           "type": "new_feature",
           "changes": [
             "Content loader has new modifier for grey backgrounds.",
-            "Red signal color has been updated, <code>#FF0000</code> -> <code>#EE0701</code>, for better contrast and validation against both black and white.",
+            "Red signal color has been updated, <code>#FF0000</code> to <code>#EE0701</code>, for better contrast and validation against both black and white.",
             "The danger button hover color has been changed and documentation for more use cases has been updated. Disabled states have also been added to documentation."
           ],
           "components": [
@@ -1652,10 +1652,10 @@
             "The <code>e-popover</code> alignments classes for left and right positions have been renamed and refactored."
           ],
           "fixes": [
-            "<code class=\"changelog-code\">e-popover--top--left</code> -> <code class=\"changelog-code\">e-popover--left</code>",
-            "<code class=\"changelog-code\">e-popover--bottom--left</code> -> <code class=\"changelog-code\">e-popover--bottom e-popover--left</code>",
-            "<code class=\"changelog-code\">e-popover--top--right</code> -> <code class=\"changelog-code\">e-popover--right</code>",
-            "<code class=\"changelog-code\">e-popover--bottom--right</code> -> <code class=\"changelog-code\">e-popover--bottom e-popover--right</code>"
+            "<code class=\"changelog-code\">e-popover--top--left</code> to <code class=\"changelog-code\">e-popover--left</code>",
+            "<code class=\"changelog-code\">e-popover--bottom--left</code> to <code class=\"changelog-code\">e-popover--bottom e-popover--left</code>",
+            "<code class=\"changelog-code\">e-popover--top--right</code> to <code class=\"changelog-code\">e-popover--right</code>",
+            "<code class=\"changelog-code\">e-popover--bottom--right</code> to <code class=\"changelog-code\">e-popover--bottom e-popover--right</code>"
           ],
           "components": [{ "displayName": "Popover", "url": "https://design.elvia.io/components/popover" }]
         },
@@ -1681,8 +1681,8 @@
             "The design and structure of tables have been updated. Tables with black headers have been removed and a wrapper class has been added."
           ],
           "fixes": [
-            "The easiest way to fix an existing header is to search and replace the classes listed here with the new classes.<ul class=\"e-list\"><li ddfdf><code class=\"changelog-code\">e-top-bar</code> -> <code class=\"changelog-code\">e-header__top-bar</code></li sdsd><li dfdfdf><code class=\"changelog-code\">e-sidebar</code> -> <code class=\"changelog-code\">e-header__sidebar</code></li sdsd><li dfdfdfd><code class=\"changelog-code\">top-bar__</code> -> <code class=\"changelog-code\">top-bar-desktop__</span></li sdsd></ul sdsd>",
-            "Add an element with the <code class=\"changelog-code\">e-table-container</code> class outside the element with the <code class=\"changelog-code\">e-table</code> class.<ul class=\"e-list\"><li ddfdf><code class=\"changelog-code\">e-table</code> -> <code class=\"changelog-code\">e-table-container e-table</code></li sdsdsd></ul>"
+            "The easiest way to fix an existing header is to search and replace the classes listed here with the new classes.<ul class=\"e-list\"><li ddfdf><code class=\"changelog-code\">e-top-bar</code> to <code class=\"changelog-code\">e-header__top-bar</code></li sdsd><li dfdfdf><code class=\"changelog-code\">e-sidebar</code> to <code class=\"changelog-code\">e-header__sidebar</code></li sdsd><li dfdfdfd><code class=\"changelog-code\">top-bar__</code> to <code class=\"changelog-code\">top-bar-desktop__</span></li sdsd></ul sdsd>",
+            "Add an element with the <code class=\"changelog-code\">e-table-container</code> class outside the element with the <code class=\"changelog-code\">e-table</code> class.<ul class=\"e-list\"><li ddfdf><code class=\"changelog-code\">e-table</code> to <code class=\"changelog-code\">e-table-container e-table</code></li sdsdsd></ul>"
           ],
           "components": [
             { "displayName": "Accordion", "url": "https://design.elvia.io/components/accordion" },
@@ -1738,7 +1738,7 @@
             "All <code class=\"changelog-code\">---visible</code> classes for Modal and Popover components are removed. New utility classes are added instead for showing and hiding elements. If you are using the Modal or Popover components you now have to use the new utility classes for hiding and showing. Theses components are by default now always visible.<div class=\"e-mt-8\"></div>"
           ],
           "fixes": [
-            "Add the <code class=\"changelog-code\">e-none</code> or <code class=\"changelog-code\">e-invisble</code> utility classes to toggle the components.<ul><li><code class=\"changelog-code\">e-component---visible</code> -> <code class=\"changelog-code\">e-none</span> & <code class=\"changelog-code\">e-invisible</code></li></ul>"
+            "Add the <code class=\"changelog-code\">e-none</code> or <code class=\"changelog-code\">e-invisble</code> utility classes to toggle the components.<ul><li><code class=\"changelog-code\">e-component---visible</code> to <code class=\"changelog-code\">e-none</span> & <code class=\"changelog-code\">e-invisible</code></li></ul>"
           ],
           "components": [
             { "displayName": "Modal", "url": "https://design.elvia.io/components/modal" },
@@ -1759,7 +1759,7 @@
         {
           "type": "breaking_changes",
           "changes": [
-            "If you are using the grid-classes some might have to be updated to work as usual. The classes that have changed / been added:<ul sdsd><li sdsd><code class=\"changelog-code\">e-grid-margin</code> -> <code class=\"changelog-code\">e-grid-margin-ext</code> + <code class=\"changelog-code\">e-grid-margin-int</code></li ssdsd><li sds><code class=\"changelog-code\">e-custom-gutters</code> -> <code class=\"changelog-code\">e-grid-gutters-ext</code> +<code class=\"changelog-code\">e-grid-gutters-int</code> + <code class=\"changelog-code\">e-grid-gutters-vertical</code></li sdd></ul sdsd>"
+            "If you are using the grid-classes some might have to be updated to work as usual. The classes that have changed / been added:<ul sdsd><li sdsd><code class=\"changelog-code\">e-grid-margin</code> to <code class=\"changelog-code\">e-grid-margin-ext</code> + <code class=\"changelog-code\">e-grid-margin-int</code></li ssdsd><li sds><code class=\"changelog-code\">e-custom-gutters</code> to <code class=\"changelog-code\">e-grid-gutters-ext</code> +<code class=\"changelog-code\">e-grid-gutters-int</code> + <code class=\"changelog-code\">e-grid-gutters-vertical</code></li sdd></ul sdsd>"
           ],
           "pages": [{ "displayName": "Grid", "url": "https://design.elvia.io/brand/grid" }]
         },


### PR DESCRIPTION
…changelog text

# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-2224
Added "breaking_changes" to changelogs that were missing it.
Removed arrows ("=>" and "->") from changelogs since it breaks filter highlighting.