### PR TITLE
fix(elvis): update jquery min version requirement for security fix

### DIFF
--- a/packages/elvis/package.json
+++ b/packages/elvis/package.json
@@ -24,7 +24,7 @@
     "@elvia/elvis-colors": "^1.8.0",
     "@elvia/elvis-typography": "^2.3.2",
     "bootstrap": "4.6.1",
-    "jquery": "1.9.1 - 3",
+    "jquery": "^3.6.4",
     "popper.js": "^1.16.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3594,7 +3594,7 @@ __metadata:
     gulp-postcss: ^8.0.0
     gulp-rename: ^2.0.0
     gulp-tap: ^2.0.0
-    jquery: 1.9.1 - 3
+    jquery: ^3.6.4
     mini-svg-data-uri: ^1.1.3
     popper.js: ^1.16.1
     resolve: ^1.20.0
@@ -3610,7 +3610,7 @@ __metadata:
     "@elvia/elvis-colors": ^1.8.0
     "@elvia/elvis-typography": ^2.3.2
     bootstrap: 4.6.1
-    jquery: 1.9.1 - 3
+    jquery: ^3.6.4
     popper.js: ^1.16.1
   languageName: node
   linkType: soft
@@ -14821,10 +14821,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jquery@npm:1.9.1 - 3":
-  version: 3.6.3
-  resolution: "jquery@npm:3.6.3"
-  checksum: 0fd366bdcaa0c84a7a8751ce20f8192290141913978b5059574426d9b01f4365daa675f95aab3eec94fd794d27b08d32078a2236bef404b8ba78073009988ce6
+"jquery@npm:^3.6.4":
+  version: 3.6.4
+  resolution: "jquery@npm:3.6.4"
+  checksum: 8354f7bd0a0424aa714ee1b6b1ef74b410f834eb5c8501682289b358bc151f11677f11188b544f3bb49309d6ec4d15d1a5de175661250c206b06185a252f706f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
`jquery` isn't even being used by anything, it's just required to have because of `bootstrap` 🤷 
To fix https://github.com/3lvia/designsystem/security/dependabot/23 I had to manually up the required version (I think, not 100% sure that this will fix things). 
There's a bug in Dependabot that makes it unable to make a PR to fix this itself because of yarn workspaces-stuff https://github.com/dependabot/dependabot-core/issues/3151