### PR TITLE
feat(ceg:controlType): make ceg types readonly

### DIFF
--- a/packages/web/src/app/shared/component-documentation/ceg/cegControlManager.ts
+++ b/packages/web/src/app/shared/component-documentation/ceg/cegControlManager.ts
@@ -4,7 +4,7 @@ import { CegControl, ComponentType, Controls, ControlValue, StaticProps } from '
 
 export type UnknownCegControlManager = CegControlManager<unknown>;
 
-export class CegControlManager<TComponentProps> {
+export class CegControlManager<TComponentProps extends Record<string, any>> {
   private _componentTypes = new BehaviorSubject<ComponentType<TComponentProps>[]>([]);
   componentTypes = this._componentTypes.asObservable();
 

--- a/packages/web/src/app/shared/component-documentation/ceg/componentExample.ts
+++ b/packages/web/src/app/shared/component-documentation/ceg/componentExample.ts
@@ -6,10 +6,10 @@ export abstract class ComponentExample<T = Record<string, any>> {
    *
    * For the component &lt;elvia-datepicker-range&gt;, this would be "datepicker-range".
    * */
-  elementName: string;
+  readonly elementName: string;
 
   /**
    * The CEG configuration.
    */
-  cegContent: CegControlManager<T>;
+  readonly cegContent: CegControlManager<T>;
 }

--- a/packages/web/src/app/shared/component-documentation/ceg/controlType.ts
+++ b/packages/web/src/app/shared/component-documentation/ceg/controlType.ts
@@ -1,68 +1,70 @@
 interface ControlBase {
-  type: string;
-  group: string;
+  readonly type: string;
+  readonly group: string;
   disabledBy?: string[];
 }
 
 export interface Checkbox extends ControlBase {
-  type: 'checkbox';
-  label: string;
+  readonly type: 'checkbox';
+  readonly label: string;
   value?: boolean;
-  children?: { [key: string]: Checkbox };
+  readonly children?: { [key: string]: Checkbox };
 }
 
 export interface RadioGroup<T = string | number> extends ControlBase {
-  type: 'radioGroup';
+  readonly type: 'radioGroup';
   value: T;
-  radios: Radio<T>[];
+  readonly radios: Radio<T>[];
 }
 
 interface Radio<T> {
-  label: string;
+  readonly label: string;
   value: T;
 }
 
 export interface Switch extends ControlBase {
-  type: 'switch';
-  label: string;
+  readonly type: 'switch';
+  readonly label: string;
   value?: boolean;
 }
 
 export interface Counter extends ControlBase {
-  type: 'counter';
-  postfix?: string;
+  readonly type: 'counter';
+  readonly postfix?: string;
   value: number;
-  increment: number;
-  min?: number;
-  max?: number;
+  readonly increment: number;
+  readonly min?: number;
+  readonly max?: number;
 }
 
 export interface Text extends ControlBase {
-  type: 'text';
-  label: string;
+  readonly type: 'text';
+  readonly label: string;
   value?: string;
-  inputType?: 'input' | 'textarea';
+  readonly inputType?: 'input' | 'textarea';
 }
 
 export type CegControl = Checkbox | Switch | RadioGroup | Counter | Text;
 
-export type Controls<T = Record<string, any>> = Partial<{
-  [key in keyof T]: T[key] extends boolean
-    ? Checkbox | Switch
-    : T[key] extends string
-    ? RadioGroup<T[key]> | Text
-    : RadioGroup | Counter | Text;
-}>;
+export type Controls<T = Record<string, any>> = Readonly<
+  Partial<{
+    [key in keyof T]: T[key] extends boolean
+      ? Checkbox | Switch
+      : T[key] extends string
+      ? RadioGroup<T[key]> | Text
+      : RadioGroup | Counter | Text;
+  }>
+>;
 
 export type StaticProps<T> = {
-  [key in keyof T]: T[key];
+  readonly [K in keyof T]: T[K];
 };
 
 export interface ComponentType<T> {
-  name?: string;
-  controls: Controls<T>;
-  groupOrder: string[];
-  staticProps?: StaticProps<T>;
+  readonly name?: string;
+  readonly controls: Controls<T>;
+  readonly groupOrder: string[];
+  readonly staticProps?: StaticProps<T>;
 }
 
 export type ControlValue = CegControl['value'];


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
Made the types that I think should be `readonly` in the CEG `readonly`. My thought is that only the `value` for a control should be mutable, everything else should not be changed at any point in runtime.