### PR TITLE
fix(docs:spotlight): update spotlight position after toggle

### DIFF
--- a/packages/web/src/app/doc-pages/components/spotlight-doc/spotlight-ceg/spotlight-ceg.component.ts
+++ b/packages/web/src/app/doc-pages/components/spotlight-doc/spotlight-ceg/spotlight-ceg.component.ts
@@ -42,6 +42,7 @@ export class SpotlightCegComponent implements ComponentExample, AfterViewInit {
   toggleSpotlight() {
     const isHidden = this.spotlight.nativeElement.classList.toggle('e-none');
     this.spotlight.nativeElement.setProps({ hasLockBodyScroll: !isHidden });
+    this.updateSpotlightPosition();
   }
 
   @HostListener('window:resize')


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
Just a quick fix to recalculate spotlight position every time it is reopened (so that it is correctly placed over the trigger)