### PR TITLE
fix(prop-table): remove duplicated search highlight for exact matches

### DIFF
--- a/packages/web/src/app/shared/component-documentation/component-properties-table/component-properties-table.component.ts
+++ b/packages/web/src/app/shared/component-documentation/component-properties-table/component-properties-table.component.ts
@@ -94,19 +94,17 @@ export class ComponentPropertiesTableComponent implements OnInit {
   }
 
   private getHighlightedHTMLString(match: Fuse.FuseResultMatch, value: string): string {
-    const usedIndices: Fuse.RangeTuple[] = [];
     // Add any part of the description that is before the first match
     let highlightedValue = value.substring(0, match.indices[0][0]);
     // Add each match, and the part of the description between matches
     match.indices
       // Filter out any duplicate matches (happens if you search the exact name of a long prop)
-      .filter((matchIndices) => {
-        if (usedIndices.find((used) => used[0] === matchIndices[0] && used[1] === matchIndices[1])) {
-          return false;
+      .reduce((usedIndices, current) => {
+        if (usedIndices.find((used) => used[0] === current[0] && used[1] === current[1])) {
+          return usedIndices;
         }
-        usedIndices.push(matchIndices);
-        return true;
-      })
+        return [...usedIndices, current];
+      }, [] as Fuse.RangeTuple[])
       .forEach((matchIndices, index, items) => {
         const [matchStart, matchEnd] = matchIndices;
         // Only highlight in description if more than one character


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-2445

How to test:
Search "dropdownSelectedItemIndexOnChange" on pagination docs, compare results in prod with this PR.