### PR TITLE
feat(CEG:controlType): add autocomplete support for radio label type

### DIFF
--- a/packages/web/src/app/shared/component-documentation/ceg/controlType.ts
+++ b/packages/web/src/app/shared/component-documentation/ceg/controlType.ts
@@ -1,3 +1,6 @@
+/** Used to allow arbitrary strings in a type union while keeping autocomplete support */
+type AnyString = string & {};
+
 interface ControlBase {
   readonly type: string;
   readonly group: string;
@@ -18,7 +21,7 @@ export interface RadioGroup<T = string | number> extends ControlBase {
 }
 
 interface Radio<T> {
-  readonly label: string;
+  readonly label: (T extends string ? Capitalize<T> : T) | AnyString;
   value: T;
 }
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
Radios most often have a label that is the same as the value, but capitalized. This adds autocomplete support for those, while still allowing arbitrary strings as labels.