### PR TITLE
Lego 2614 - fix(accordion): no longer apply transition all to content

### DIFF
--- a/packages/components/components/elvis-accordion/CHANGELOG.json
+++ b/packages/components/components/elvis-accordion/CHANGELOG.json
@@ -2,6 +2,22 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "07.06.23",
+      "version": "2.9.4",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed a bug that caused the accordion to apply <code>transition: all</code> to its content."
+          ]
+        },
+        {
+          "type": "patch",
+          "changes": ["Updated internal dependencies."]
+        }
+      ]
+    },
+    {
       "date": "24.05.23",
       "version": "2.9.3",
       "changelog": [

--- a/packages/components/components/elvis-accordion/package.json
+++ b/packages/components/components/elvis-accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-accordion",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "main": "web_component.js",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/accordion",
@@ -13,11 +13,11 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "@elvia/elvis-assets-icons": "^3.0.0",
-    "@elvia/elvis-colors": "^2.2.0",
+    "@elvia/elvis-assets-icons": "^3.0.1",
+    "@elvia/elvis-colors": "^2.7.1",
     "@elvia/elvis-component-wrapper": "^4.1.2",
-    "@elvia/elvis-toolbox": "^8.0.0",
-    "@elvia/elvis-typography": "^2.3.2",
+    "@elvia/elvis-toolbox": "^9.2.0",
+    "@elvia/elvis-typography": "^2.4.0",
     "styled-components": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/components/components/elvis-accordion/src/react/styledComponents.tsx
+++ b/packages/components/components/elvis-accordion/src/react/styledComponents.tsx
@@ -205,6 +205,7 @@ export const AccordionContent = styled.div<AccordionContentProps>`
   opacity: ${({ isOpenState, type }) => decideContentOpacity(isOpenState, type)};
   overflow-y: hidden;
   transition: all ${({ contentHeight }) => decideContentTransitionDuration(contentHeight)} ${bezierCurve};
+  transition-property: opacity, max-height, visibility;
   -ms-overflow-style: none;
   scrollbar-width: none;
   &::-webkit-scrollbar {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,11 +2653,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-accordion@workspace:packages/components/components/elvis-accordion"
   dependencies:
-    "@elvia/elvis-assets-icons": ^3.0.0
-    "@elvia/elvis-colors": ^2.2.0
+    "@elvia/elvis-assets-icons": ^3.0.1
+    "@elvia/elvis-colors": ^2.7.1
     "@elvia/elvis-component-wrapper": ^4.1.2
-    "@elvia/elvis-toolbox": ^8.0.0
-    "@elvia/elvis-typography": ^2.3.2
+    "@elvia/elvis-toolbox": ^9.2.0
+    "@elvia/elvis-typography": ^2.4.0
     styled-components: ^5.3.3
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -2673,7 +2673,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elvia/elvis-assets-icons@*, @elvia/elvis-assets-icons@^3.0.0, @elvia/elvis-assets-icons@workspace:*, @elvia/elvis-assets-icons@workspace:packages/elvis-assets-icons":
+"@elvia/elvis-assets-icons@*, @elvia/elvis-assets-icons@^3.0.0, @elvia/elvis-assets-icons@^3.0.1, @elvia/elvis-assets-icons@workspace:*, @elvia/elvis-assets-icons@workspace:packages/elvis-assets-icons":
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-assets-icons@workspace:packages/elvis-assets-icons"
   dependencies:
@@ -2848,7 +2848,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elvia/elvis-colors@^2.2.0, @elvia/elvis-colors@^2.3.0, @elvia/elvis-colors@^2.4.0, @elvia/elvis-colors@^2.6.0, @elvia/elvis-colors@workspace:*, @elvia/elvis-colors@workspace:packages/elvis-colors":
+"@elvia/elvis-colors@^2.2.0, @elvia/elvis-colors@^2.3.0, @elvia/elvis-colors@^2.4.0, @elvia/elvis-colors@^2.6.0, @elvia/elvis-colors@^2.7.1, @elvia/elvis-colors@workspace:*, @elvia/elvis-colors@workspace:packages/elvis-colors":
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-colors@workspace:packages/elvis-colors"
   dependencies:
@@ -3407,7 +3407,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elvia/elvis-toolbox@*, @elvia/elvis-toolbox@^9.0.0, @elvia/elvis-toolbox@^9.1.0, @elvia/elvis-toolbox@workspace:packages/components/components/elvis-toolbox":
+"@elvia/elvis-toolbox@*, @elvia/elvis-toolbox@^9.0.0, @elvia/elvis-toolbox@^9.1.0, @elvia/elvis-toolbox@^9.2.0, @elvia/elvis-toolbox@workspace:packages/components/components/elvis-toolbox":
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-toolbox@workspace:packages/components/components/elvis-toolbox"
   dependencies:
@@ -3500,7 +3500,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elvia/elvis-typography@*, @elvia/elvis-typography@^2.3.1, @elvia/elvis-typography@^2.3.2, @elvia/elvis-typography@workspace:*, @elvia/elvis-typography@workspace:packages/elvis-typography":
+"@elvia/elvis-typography@*, @elvia/elvis-typography@^2.3.1, @elvia/elvis-typography@^2.3.2, @elvia/elvis-typography@^2.4.0, @elvia/elvis-typography@workspace:*, @elvia/elvis-typography@workspace:packages/elvis-typography":
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-typography@workspace:packages/elvis-typography"
   dependencies:


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-2614