### PR TITLE
feat(design.elvia.io): add support for copying section links with keyboard

### DIFF
--- a/packages/web/src/app/shared/component-documentation/component-structure/component-section/component-section.component.html
+++ b/packages/web/src/app/shared/component-documentation/component-structure/component-section/component-section.component.html
@@ -5,6 +5,7 @@
     <app-copy
       tabindex="0"
       (click)="copyAnchor()"
+      (keydown.enter)="copyAnchor()"
       style="position: absolute; height: 24px; left: -36px; width: 36px"
     >
       <ng-container ngProjectAs="copyContent">

--- a/packages/web/src/app/shared/component-documentation/component-structure/component-section/component-section.component.scss
+++ b/packages/web/src/app/shared/component-documentation/component-structure/component-section/component-section.component.scss
@@ -24,8 +24,11 @@
     align-items: center;
     border-bottom: 1px solid var(--e-black);
 
-    &:hover .icons .normal-img {
-      display: block;
+    &:hover,
+    &:focus-within {
+      .icons .normal-img {
+        display: block;
+      }
     }
 
     .icons {
@@ -40,11 +43,13 @@
         padding-right: 12px;
       }
     }
-    &.anchor-copied .icons .green-img {
-      display: block;
-    }
-    &.anchor-copied .icons .normal-img {
-      display: none;
+    &.anchor-copied .icons {
+      .green-img {
+        display: block;
+      }
+      .normal-img {
+        display: none;
+      }
     }
   }
 }

--- a/packages/web/src/app/shared/component-documentation/component-structure/component-section/component-section.component.ts
+++ b/packages/web/src/app/shared/component-documentation/component-structure/component-section/component-section.component.ts
@@ -22,7 +22,7 @@ export class ComponentSectionComponent {
     setTimeout(() => {
       anchorTitleElement.classList.remove('anchor-copied');
     }, 800);
-    const modifiedAnchor = this.sectionTitle.replace(' ', '-');
+    const modifiedAnchor = this.sectionTitle.replace(/ /g, '-');
     let anchorUrl = 'https://design.elvia.io';
     if (this.router.url.includes('#')) {
       anchorUrl =


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
The copy-anchor image on the left side of component section titles now shows on focus, and you can copy the link by clicking enter.
Also fixed a bug where sections with titles that contained more than one space would not copy link properly (e.g. "For content creators" under "Get started").