### PR TITLE
chore(yarn): ignore missing transient peer dependencies log warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,4 +12,12 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: '@yarnpkg/plugin-interactive-tools'
 
+logFilters:
+  - pattern: "@angular-eslint/* doesn't provide *"
+    level: 'discard'
+  - pattern: "@nrwl/* doesn't provide *"
+    level: 'discard'
+  - pattern: "stylelint-selector-bem-pattern@* doesn't provide eslint"
+    level: 'discard'
+
 yarnPath: .yarn/releases/yarn-3.5.0.cjs


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
Ignore the warnings from running `yarn` on some missing transient peer dependencies, as we can't control this and it's cluttering the terminal.

Before: 
<img width="692" alt="image" src="https://github.com/3lvia/designsystem/assets/38653456/2dca80ac-06b4-4560-a3a1-6fa0383e7ca6">

After:
<img width="691" alt="image" src="https://github.com/3lvia/designsystem/assets/38653456/0d876e21-2bf9-4d62-9c2d-a0fcf27ee700">
