### PR TITLE
fix(table): multiline cell no longer add whitespace to start

### DIFF
--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -2,12 +2,13 @@
   "content": [
     {
       "version": "12.11.1",
-      "date": "September 11, 2023",
+      "date": "September 12, 2023",
       "changelog": [
         {
           "type": "bug_fix",
           "changes": [
-            "Table header theme background color fix",
+            "Fixed the <code>e-table__cell--multiline</code> class to not add whitespace at the start of a table cell.",
+            "Table header theme background color fix.",
             "Removed <code>e-form-field--small</code> class from deprecated list. Should not have been deprecated."
           ],
           "components": [

--- a/packages/elvis/package.json
+++ b/packages/elvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis",
-  "version": "12.11.0",
+  "version": "12.11.1",
   "description": "Elvia design system",
   "license": "ISC",
   "homepage": "https://design.elvia.io/",

--- a/packages/elvis/src/components/table.scss
+++ b/packages/elvis/src/components/table.scss
@@ -123,7 +123,7 @@ $table-invalid-padding: 8px 16px;
       max-width: 450px;
       height: auto;
       vertical-align: top;
-      white-space: pre-wrap;
+      white-space: normal;
     }
 
     &.e-table__cell--multiline-small,
@@ -133,7 +133,7 @@ $table-invalid-padding: 8px 16px;
       max-width: 250px;
       height: auto;
       vertical-align: top;
-      white-space: pre-wrap;
+      white-space: normal;
     }
   }
 

--- a/packages/web/src/app/doc-pages/components/table-doc/table-long-column-ceg/table-long-column-ceg.component.html
+++ b/packages/web/src/app/doc-pages/components/table-doc/table-long-column-ceg/table-long-column-ceg.component.html
@@ -12,8 +12,9 @@
     <tbody>
       <tr>
         <th scope="row" class="e-table__cell--multiline">
-          This cell exceeds 450px in width, so the class 'e-table__cell--multiline' should be added to break
-          the lines.
+          This cell exceeds 450px in width, so the class
+          <code>e-table__cell--multiline</code>
+          should be added to break the lines.
         </th>
         <td>Sent</td>
         <td class="e-text-right e-text-mono">567,98</td>


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-2941

Bump elvis, since the last fix wasn't published I added this fix to the same version in the changelog.