### PR TITLE
Lego 2906 sortere props og events i tabellen

### DIFF
--- a/packages/web/src/app/shared/component-documentation/component-properties-table/table-base.ts
+++ b/packages/web/src/app/shared/component-documentation/component-properties-table/table-base.ts
@@ -42,8 +42,12 @@ export class PropertyTableBaseDirective implements OnChanges {
   }
 
   private sortProps(a: SearchResult<ComponentProp>, b: SearchResult<ComponentProp>): number {
-    if (['className', 'inlineStyle'].includes(a.item.attribute)) {
-      return 1;
+    const lastProps = ['className', 'inlineStyle'];
+    let lastPropComparison = 0;
+    if (lastProps.includes(a.item.attribute) && !lastProps.includes(b.item.attribute)) {
+      lastPropComparison = 1;
+    } else if (!lastProps.includes(a.item.attribute) && lastProps.includes(b.item.attribute)) {
+      lastPropComparison = -1;
     }
 
     let requiredComparison = 0;
@@ -55,6 +59,6 @@ export class PropertyTableBaseDirective implements OnChanges {
 
     const alphabeticalComparison = a.item.attribute.localeCompare(b.item.attribute);
 
-    return requiredComparison || alphabeticalComparison;
+    return lastPropComparison || requiredComparison || alphabeticalComparison;
   }
 }


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
- Added a method `sortProps` in `table-base.ts` that simply sorts all props by the following logic:
  - Required props are placed at the top, internally sorted alphabetical
  - All other props follows, sorted alphabetical
  - `className` and `inlineStyle` are placed last
