### PR TITLE
fix(web): multiple elvia-toast elements in DOM

### DIFF
--- a/packages/web/src/app/app.component.html
+++ b/packages/web/src/app/app.component.html
@@ -1,4 +1,5 @@
 <app-header></app-header>
+<elvia-toast></elvia-toast>
 
 <main [ngClass]="{ 'not-found': currentRoute === 'notFound' }">
   <ng-container *ngIf="currentRoute !== 'pageWithSidenav'; else pageWithSidenav">

--- a/packages/web/src/app/dev/v2-playground/v2-playground.component.html
+++ b/packages/web/src/app/dev/v2-playground/v2-playground.component.html
@@ -688,7 +688,6 @@
         <!--Toast-->
         <div class="example-wrapper">
           <h3>Toast</h3>
-          <elvia-toast></elvia-toast>
           <button (click)="showToast()">Show toast</button>
         </div>
 

--- a/packages/web/src/app/doc-pages/components/toast-doc/toast-ceg/toast-ceg.component.html
+++ b/packages/web/src/app/doc-pages/components/toast-doc/toast-ceg/toast-ceg.component.html
@@ -1,2 +1,1 @@
-<elvia-toast></elvia-toast>
 <button class="e-btn" (click)="showToast()">Show example toast</button>

--- a/packages/web/src/app/shared/component-documentation/ceg/ceg.component.ts
+++ b/packages/web/src/app/shared/component-documentation/ceg/ceg.component.ts
@@ -68,10 +68,18 @@ export class CegComponent implements AfterViewInit, AfterContentInit, OnDestroy 
   ) {}
 
   ngAfterViewInit(): void {
+    let hasPropControls = true;
+    const controls = this.componentExample.cegContent.getControlSnapshot();
+    if (controls) {
+      hasPropControls = Object.values(controls).some((control) => !control?.excludedFromDOM);
+    }
+
     this.setCegStateFromURL();
-    this.setUpSlotSubscription();
-    this.setUpTypeChangeSubscription();
-    this.setUpStaticPropSubscription();
+    if (hasPropControls) {
+      this.setUpSlotSubscription();
+      this.setUpTypeChangeSubscription();
+      this.setUpStaticPropSubscription();
+    }
   }
 
   ngAfterContentInit(): void {


### PR DESCRIPTION
The fix is to only provide the elvia-toast on root level of the app. This means that the CEG must handle a new case where the component example template is missing the web component it documents.

# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
