### PR TITLE
build: set common rootdir so that it does not fluctuate during rebuilds

### DIFF
--- a/packages/components/build/dts.plugin.ts
+++ b/packages/components/build/dts.plugin.ts
@@ -49,6 +49,7 @@ const dtsPlugin = (config: Props) =>
         skipLibCheck: true,
         jsx: ts.JsxEmit.React,
         declarationMap: config.watchMode,
+        rootDir: 'components',
       };
 
       const host = ts.createCompilerHost(tsConfig);


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
By default, TypeScript will define the path to a file by the lowest common file path of the files to compile. During a full build, that is the `components` folder. However, when we change a single file and save, TypeScript will only rebuild that file (and possibly some type files). In these cases, the lowest common path is usually the `src` folder for that component. This fluctuating path makes the build write the files to different locations on a complete build and "hot reload". 

This PR changes this by specifying to TypeScript that the root directory always should be `components`.