### PR TITLE
fix(web): correct name and url for css library on home page

### DIFF
--- a/packages/web/src/app/home/front-page-changelog/front-page-changelog.component.html
+++ b/packages/web/src/app/home/front-page-changelog/front-page-changelog.component.html
@@ -14,9 +14,9 @@
             ? '/components/css-library'
             : '/components/' + (changelog.name | FrontPageChangelogUrlPipe)
         "
-        [fragment]="changelog.name !== 'elvis' ? 'Changelog' : undefined"
+        fragment="Changelog"
       >
-        {{ changelog.name | FrontPageChangelogNamePipe }}
+        {{ changelog.name === 'elvis' ? 'CSS Library' : (changelog.name | FrontPageChangelogNamePipe) }}
       </a>
     </td>
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
- "Elvis" is now called "CSS Library" in the "Whats new"-section of the home page
- The "CSS Library" link will now go straight to the "Changelog" section