### PR TITLE
fix(timepicker): trigger validation on blur when input is empty

### DIFF
--- a/packages/components/components/elvis-timepicker/CHANGELOG.json
+++ b/packages/components/components/elvis-timepicker/CHANGELOG.json
@@ -2,6 +2,18 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "9.11.23",
+      "version": "5.1.1",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed an issue where the error would not update if the input field was cleared when the time picker is not required."
+          ]
+        }
+      ]
+    },
+    {
       "date": "10.10.23",
       "version": "5.1.0",
       "changelog": [

--- a/packages/components/components/elvis-timepicker/package.json
+++ b/packages/components/components/elvis-timepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-timepicker",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/timepicker",
   "source": "src/react/elvia-timepicker.tsx",

--- a/packages/components/components/elvis-timepicker/src/react/timepickerInput.tsx
+++ b/packages/components/components/elvis-timepicker/src/react/timepickerInput.tsx
@@ -162,6 +162,7 @@ export const TimepickerInput: React.FC<Props> = ({
     // Always emit empty values
     if (!inputValue.length) {
       onChange(null);
+      onErrorChange(!isValid ? 'required' : undefined);
       return;
     }
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3162