### PR TITLE
fix(icon-doc): static black text to text-1

### DIFF
--- a/packages/web/src/app/doc-pages/brand/icon-doc/icon-doc.component.html
+++ b/packages/web/src/app/doc-pages/brand/icon-doc/icon-doc.component.html
@@ -21,7 +21,7 @@
             <div class="e-alert__title">{{ icon.pretty }}</div>
             <div class="e-alert__text">
               <div style="display: flex; flex-direction: row; justify-content: space-between">
-                <div class="e-text-sm e-text-grey-70">e-icon e-icon--{{ icon.title }} e-icon--sm</div>
+                <div class="e-text-sm e-color-text-2">e-icon e-icon--{{ icon.title }} e-icon--sm</div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3178

Fixes the "Copy"-text for dark theme in icon doc when you copy an icons elvis-class.