### PR TITLE
docs(toast-ceg): change toast body based on status

### DIFF
--- a/packages/web/src/app/doc-pages/components/toast-doc/toast-ceg/toast-ceg.component.ts
+++ b/packages/web/src/app/doc-pages/components/toast-doc/toast-ceg/toast-ceg.component.ts
@@ -39,6 +39,7 @@ export class ToastCegComponent extends TypescriptComponentExample implements Com
           group: 'Title',
           label: 'Title',
           value: '',
+          placeholder: 'Title for the toast',
           excludedFromDOM: true,
         },
         body: {


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3320

This works, except some weirdness if you change status and manually write a change to the body, then reload the page. It still works, but the CEG filter value stored in the URL params may be out of date with what is in the CEG.