### PR TITLE
fix(elvis): text area overflows when used with a button

### DIFF
--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -1,6 +1,17 @@
 {
   "content": [
     {
+      "version": "15.6.3",
+      "date": "January 19, 2024",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": ["Fixed an issue where the text would overflow over an icon button in text area."],
+          "components": [{ "displayName": "Text Field", "url": "https://design.elvia.io/components/input" }]
+        }
+      ]
+    },
+    {
       "version": "15.6.2",
       "date": "January 10, 2024",
       "changelog": [

--- a/packages/elvis/package.json
+++ b/packages/elvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis",
-  "version": "15.6.2",
+  "version": "15.6.3",
   "description": "Elvia design system",
   "license": "ISC",
   "homepage": "https://design.elvia.io/",

--- a/packages/elvis/src/components/form/input.scss
+++ b/packages/elvis/src/components/form/input.scss
@@ -68,7 +68,8 @@ $form-input-padding-compact-active: 3px 9px;
     right: 4px;
   }
 
-  &:has(.e-btn.e-btn--icon) > input {
+  &:has(.e-btn.e-btn--icon) > input,
+  &:has(.e-btn.e-btn--icon) > textarea {
     padding-right: 40px;
   }
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
