### PR TITLE
fix(datepicker-range): add missing dependency to icons package

### DIFF
--- a/packages/components/components/elvis-datepicker-range/CHANGELOG.json
+++ b/packages/components/components/elvis-datepicker-range/CHANGELOG.json
@@ -2,6 +2,16 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "30.01.24",
+      "version": "5.0.6",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": ["Added a missing dependency to <code>@elvia/elvis-assets-icons</code>."]
+        }
+      ]
+    },
+    {
       "date": "09.01.24",
       "version": "5.0.5",
       "changelog": [

--- a/packages/components/components/elvis-datepicker-range/package.json
+++ b/packages/components/components/elvis-datepicker-range/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-datepicker-range",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/datepicker-range",
   "source": "src/react/elvia-datepicker-range.tsx",
@@ -11,6 +11,7 @@
     "dist"
   ],
   "dependencies": {
+    "@elvia/elvis-assets-icons": "^3.9.0",
     "@elvia/elvis-component-wrapper": "^4.2.0",
     "@elvia/elvis-datepicker": "^9.0.4",
     "@elvia/elvis-timepicker": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,6 +2602,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-datepicker-range@workspace:packages/components/components/elvis-datepicker-range"
   dependencies:
+    "@elvia/elvis-assets-icons": "npm:^3.9.0"
     "@elvia/elvis-component-wrapper": "npm:^4.2.0"
     "@elvia/elvis-datepicker": "npm:^9.0.4"
     "@elvia/elvis-timepicker": "npm:^5.1.1"


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3355

The problem doesnt happen in our repo, but I assume its because kunde-web is using `Yarn PnP` (which doesn't allow implicit hoisting of dependencies) whereas we use `Yarn node-modules`.