### PR TITLE
fix(header.component): add static header links instead of content loader

### DIFF
--- a/packages/web/src/app/shell/header/header.component.html
+++ b/packages/web/src/app/shell/header/header.component.html
@@ -7,9 +7,6 @@
       <img [src]="logoUrl" class="elvia-logo" alt="Elvia Logo" />
     </a>
 
-    @if (menuContentLoader) {
-      <div class="tabs-content-loader e-none-sm e-none-md e-content-loader e-ml-48"></div>
-    }
     @if (mainMenu) {
       <nav class="tabs e-ml-32 e-none-sm e-none-md" aria-label="tabs navigation" role="tablist">
         @for (menuItem of mainMenu.pages; track menuItem) {

--- a/packages/web/src/app/shell/header/header.component.ts
+++ b/packages/web/src/app/shell/header/header.component.ts
@@ -41,8 +41,21 @@ type MenuType = 'search' | 'mobileMenu' | null;
 })
 export class HeaderComponent {
   visibleMenuType: MenuType = null;
-  mainMenu: CMSMenu;
-  menuContentLoader = true;
+  mainMenu: CMSMenu = {
+    title: 'Main menu',
+    pages: [
+      { title: 'About', path: '/about', entry_id: '"4QCCWwLq5R3TQZRhFjxT96"', entry: undefined as any },
+      { title: 'Brand', path: '/brand', entry_id: '"2p2DsRycYl2iqVBJ8UFMay"', entry: undefined as any },
+      {
+        title: 'Components',
+        path: '/components',
+        entry_id: '"6RHCZ59jMvJZjcCMMsjvKk"',
+        entry: undefined as any,
+      },
+      { title: 'Patterns', path: '/patterns', entry_id: '"5oUsPjHfF6bNDHqub1EaFl"', entry: undefined as any },
+      { title: 'Tools', path: '/tools', entry_id: '"6zwtCTRgovdJkF91Fkh4jN"', entry: undefined as any },
+    ],
+  };
   themeMenuIsOpen = false;
   currentTheme: Theme = 'light';
 
@@ -77,10 +90,8 @@ export class HeaderComponent {
       .listenLocalization()
       .pipe(takeUntilDestroyed())
       .subscribe(() => {
-        // The main menu is only available in english until more pages are translated
         this.cmsService.getMenu('en-GB').then((data) => {
           this.mainMenu = data;
-          this.menuContentLoader = false;
         });
       });
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3439

Added static main menu links. When the CMS-service responds with the CMS-entry, it is replaced (so if the main menu changes in the CMS, it will be updated here to after a little delay)