### PR TITLE
feat: add repository field to all published npm packages

### DIFF
--- a/packages/components/components/elvis-accordion/package.json
+++ b/packages/components/components/elvis-accordion/package.json
@@ -3,6 +3,11 @@
   "version": "3.2.2",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/accordion",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-accordion"
+  },
   "source": "src/react/elvia-accordion.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-autocomplete/package.json
+++ b/packages/components/components/elvis-autocomplete/package.json
@@ -3,6 +3,11 @@
   "version": "3.1.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/autocomplete",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-autocomplete"
+  },
   "source": "src/react/elvia-autocomplete.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-badge/package.json
+++ b/packages/components/components/elvis-badge/package.json
@@ -3,6 +3,11 @@
   "version": "2.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/badge",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-badge"
+  },
   "source": "src/react/elvia-badge.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-box/package.json
+++ b/packages/components/components/elvis-box/package.json
@@ -3,6 +3,11 @@
   "version": "2.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/box",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-box"
+  },
   "source": "src/react/elvia-box.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-breadcrumb/package.json
+++ b/packages/components/components/elvis-breadcrumb/package.json
@@ -3,6 +3,11 @@
   "version": "2.3.4",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/breadcrumb",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-breadcrumb"
+  },
   "source": "src/react/elvia-breadcrumb.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-card/package.json
+++ b/packages/components/components/elvis-card/package.json
@@ -3,6 +3,11 @@
   "version": "3.4.4",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/card",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-card"
+  },
   "source": "src/react/elvia-card.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-carousel/package.json
+++ b/packages/components/components/elvis-carousel/package.json
@@ -3,6 +3,11 @@
   "version": "3.1.2",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/carousel",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-carousel"
+  },
   "source": "src/react/elvia-carousel.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-chip/package.json
+++ b/packages/components/components/elvis-chip/package.json
@@ -3,6 +3,11 @@
   "version": "2.5.2",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/chip",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-chip"
+  },
   "source": "src/react/elvia-chip.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-component-wrapper/package.json
+++ b/packages/components/components/elvis-component-wrapper/package.json
@@ -2,6 +2,11 @@
   "name": "@elvia/elvis-component-wrapper",
   "version": "4.2.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-component-wrapper"
+  },
   "source": "src/elvia-component.ts",
   "main": "dist/elvia-component.js",
   "types": "dist/elvia-component.d.ts",

--- a/packages/components/components/elvis-context-menu/package.json
+++ b/packages/components/components/elvis-context-menu/package.json
@@ -3,6 +3,11 @@
   "version": "1.4.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/context-menu",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-context-menu"
+  },
   "source": "src/react/elvia-context-menu.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-datepicker-range/package.json
+++ b/packages/components/components/elvis-datepicker-range/package.json
@@ -3,6 +3,11 @@
   "version": "5.0.7",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/datepicker-range",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-datepicker-range"
+  },
   "source": "src/react/elvia-datepicker-range.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-datepicker/package.json
+++ b/packages/components/components/elvis-datepicker/package.json
@@ -3,6 +3,11 @@
   "version": "9.0.7",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/datepicker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-datepicker"
+  },
   "source": "src/react/elvia-datepicker.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-divider/package.json
+++ b/packages/components/components/elvis-divider/package.json
@@ -3,6 +3,11 @@
   "version": "3.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/divider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-divider"
+  },
   "source": "src/react/elvia-divider.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-dropdown/package.json
+++ b/packages/components/components/elvis-dropdown/package.json
@@ -3,6 +3,11 @@
   "version": "9.4.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/dropdown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-dropdown"
+  },
   "source": "src/react/elvia-dropdown.tsx",
   "main": "web_component.js",
   "files": [

--- a/packages/components/components/elvis-header/package.json
+++ b/packages/components/components/elvis-header/package.json
@@ -3,6 +3,11 @@
   "version": "1.9.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/header",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-header"
+  },
   "source": "src/react/elvia-header.tsx",
   "main": "web_component.js",
   "files": [

--- a/packages/components/components/elvis-icon/package.json
+++ b/packages/components/components/elvis-icon/package.json
@@ -3,6 +3,11 @@
   "version": "2.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/brand/icon#Implementation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-icon"
+  },
   "source": "src/react/elvia-icon.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-modal/package.json
+++ b/packages/components/components/elvis-modal/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.5",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/modal",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-modal"
+  },
   "source": "src/react/elvia-modal.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-outline/package.json
+++ b/packages/components/components/elvis-outline/package.json
@@ -3,6 +3,11 @@
   "version": "1.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/outline",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-outline"
+  },
   "source": "src/react/elvia-outline.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-pagination/package.json
+++ b/packages/components/components/elvis-pagination/package.json
@@ -3,6 +3,11 @@
   "version": "3.5.3",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/pagination",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-pagination"
+  },
   "source": "src/react/elvia-pagination.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-popover/package.json
+++ b/packages/components/components/elvis-popover/package.json
@@ -3,6 +3,11 @@
   "version": "7.3.4",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/popover",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-popover"
+  },
   "source": "src/react/elvia-popover.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-progress-linear/package.json
+++ b/packages/components/components/elvis-progress-linear/package.json
@@ -3,6 +3,11 @@
   "version": "2.5.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/progressbar",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-progress-linear"
+  },
   "source": "src/react/elvia-progress-linear.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-radio-filter/package.json
+++ b/packages/components/components/elvis-radio-filter/package.json
@@ -3,6 +3,11 @@
   "version": "1.8.2",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/radio-filter",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-radio-filter"
+  },
   "source": "src/react/elvia-radio-filter.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-segmented-control/package.json
+++ b/packages/components/components/elvis-segmented-control/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/segmented-control",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-segmented-control"
+  },
   "source": "src/react/elvia-segmented-control.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-slider/package.json
+++ b/packages/components/components/elvis-slider/package.json
@@ -3,6 +3,11 @@
   "version": "5.0.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/slider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-slider"
+  },
   "source": "src/react/elvia-slider.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-spotlight/package.json
+++ b/packages/components/components/elvis-spotlight/package.json
@@ -3,6 +3,11 @@
   "version": "1.6.3",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/spotlight",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-spotlight"
+  },
   "source": "src/react/elvia-spotlight.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-stepper/package.json
+++ b/packages/components/components/elvis-stepper/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/stepper",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-stepper"
+  },
   "source": "src/react/elvia-stepper.tsx",
   "main": "web_component.js",
   "files": [

--- a/packages/components/components/elvis-tabs/package.json
+++ b/packages/components/components/elvis-tabs/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.3",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/tabs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-tabs"
+  },
   "source": "src/react/elvia-tabs.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/components/components/elvis-timepicker/package.json
+++ b/packages/components/components/elvis-timepicker/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/timepicker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-timepicker"
+  },
   "source": "src/react/elvia-timepicker.tsx",
   "main": "web_component.js",
   "files": [

--- a/packages/components/components/elvis-toast/package.json
+++ b/packages/components/components/elvis-toast/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/toast",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-toast"
+  },
   "source": "src/react/elvia-toast.tsx",
   "main": "web_component.js",
   "files": [

--- a/packages/components/components/elvis-toolbox/package.json
+++ b/packages/components/components/elvis-toolbox/package.json
@@ -2,6 +2,11 @@
   "name": "@elvia/elvis-toolbox",
   "version": "11.5.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-toolbox"
+  },
   "source": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/components/components/elvis-tooltip/package.json
+++ b/packages/components/components/elvis-tooltip/package.json
@@ -3,6 +3,11 @@
   "version": "1.3.3",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/tooltip",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/components/components/elvis-tooltip"
+  },
   "source": "src/react/elvia-tooltip.tsx",
   "main": "dist/main/web-component.js",
   "files": [

--- a/packages/elvis-assets-icons/package.json
+++ b/packages/elvis-assets-icons/package.json
@@ -3,6 +3,11 @@
   "version": "3.10.0",
   "description": "Elvia icons",
   "license": "GPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/elvis-assets-icons"
+  },
   "main": "icons.js",
   "types": "icons.d.ts",
   "scripts": {

--- a/packages/elvis-colors/package.json
+++ b/packages/elvis-colors/package.json
@@ -3,6 +3,11 @@
   "version": "4.4.1",
   "description": "Elvia colors",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/elvis-colors"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/elvis-illustrations/package.json
+++ b/packages/elvis-illustrations/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.1",
   "description": "Elvia illustrations",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/elvis-illustrations"
+  },
   "type": "module",
   "exports": {
     "./CHANGELOG.json": "./CHANGELOG.json",

--- a/packages/elvis-typography/package.json
+++ b/packages/elvis-typography/package.json
@@ -3,6 +3,11 @@
   "version": "2.7.1",
   "description": "Elvia typography",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/elvis-typography"
+  },
   "main": "dist/elviaTypography.js",
   "module": "dist/elviaTypography.mjs",
   "types": "dist/elviaTypography.d.ts",

--- a/packages/elvis/package.json
+++ b/packages/elvis/package.json
@@ -4,6 +4,11 @@
   "description": "Elvia design system",
   "license": "GPL-3.0-only",
   "homepage": "https://design.elvia.io/components/css-library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3lvia/designsystem.git",
+    "directory": "packages/elvis"
+  },
   "main": "elvis.js",
   "style": "css/elvis.min.css",
   "scripts": {


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
This adds support for running the command `npm repo PACKAGE_NAME` to get to the GitHub repo of our packages. Currently, `npm home PACKAGE_NAME` sends to the documentation page on design.elvia.io.