### PR TITLE
Change color inheritance on typography mixins

### DIFF
--- a/packages/elvis-typography/CHANGELOG.md
+++ b/packages/elvis-typography/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Elvia Typography Changelog
 
+## 3.1.1 (05.09.24)
+
+### Minor
+
+- Removed "color: inherit" from all typographies.
+
 ## 3.1.0 (31.07.24)
 
 ### Minor

--- a/packages/elvis-typography/package.json
+++ b/packages/elvis-typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-typography",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Elvia typography",
   "license": "MIT",
   "repository": {

--- a/packages/elvis-typography/src/elviaTypography.ts
+++ b/packages/elvis-typography/src/elviaTypography.ts
@@ -78,7 +78,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-interactive-md': {
     altLabels: ['text-interactive-medium'],
@@ -89,7 +88,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-interactive-sm': {
     altLabels: ['text-interactive-small'],
@@ -100,7 +98,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-lead': {

--- a/packages/elvis-typography/src/elviaTypography.ts
+++ b/packages/elvis-typography/src/elviaTypography.ts
@@ -9,7 +9,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'title-md': {
@@ -22,7 +21,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'title-sm': {
@@ -35,7 +33,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'title-xs': {
@@ -48,7 +45,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'title-xxs': {
@@ -60,7 +56,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'title-caps': {
@@ -72,7 +67,6 @@ export const ElviaTypography = {
     letterSpacing: '0.05rem',
     fontStyle: 'unset',
     textTransform: 'uppercase',
-    color: 'inherit',
   },
 
   'text-interactive-lg': {
@@ -84,7 +78,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-interactive-md': {
     altLabels: ['text-interactive-medium'],
@@ -95,7 +88,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-interactive-sm': {
     altLabels: ['text-interactive-small'],
@@ -106,7 +98,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-lead': {
@@ -118,7 +109,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-lg': {
@@ -131,7 +121,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-lg-strong': {
@@ -144,7 +133,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-lg-light': {
@@ -157,7 +145,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-lg-mono': {
     altLabels: ['text-large-mono'],
@@ -181,7 +168,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-md-strong': {
     altLabels: ['text-medium-strong'],
@@ -193,7 +179,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-md-light': {
     altLabels: ['text-medium-light'],
@@ -205,7 +190,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-md-mono': {
     altLabels: ['text-medium-mono'],
@@ -228,7 +212,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-sm-strong': {
     altLabels: ['text-small-strong'],
@@ -239,7 +222,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-sm-light': {
     altLabels: ['text-small-light'],
@@ -250,7 +232,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-sm-mono': {
     altLabels: ['text-small-mono'],
@@ -271,7 +252,6 @@ export const ElviaTypography = {
     letterSpacing: '0.0125rem',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-micro-strong': {
     fontFamily: '"Red Hat Text", Verdana, sans-serif',
@@ -281,7 +261,6 @@ export const ElviaTypography = {
     letterSpacing: '0.0125rem',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-micro-light': {
     fontFamily: '"Red Hat Text", Verdana, sans-serif',
@@ -291,7 +270,6 @@ export const ElviaTypography = {
     letterSpacing: '0.0125rem',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-quote': {
@@ -303,7 +281,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'italic',
     textTransform: 'unset',
-    color: 'inherit',
   },
 
   'text-img': {
@@ -315,7 +292,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'italic',
     textTransform: 'unset',
-    color: 'inherit',
     textAlign: 'center',
   },
 
@@ -328,7 +304,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
   'text-option': {
     deprecated: '1.0.0',
@@ -339,7 +314,6 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
-    color: 'inherit',
   },
 };
 

--- a/packages/elvis-typography/src/elviaTypography.ts
+++ b/packages/elvis-typography/src/elviaTypography.ts
@@ -78,6 +78,7 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
+    color: 'inherit',
   },
   'text-interactive-md': {
     altLabels: ['text-interactive-medium'],
@@ -88,6 +89,7 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
+    color: 'inherit',
   },
   'text-interactive-sm': {
     altLabels: ['text-interactive-small'],
@@ -98,6 +100,7 @@ export const ElviaTypography = {
     letterSpacing: 'unset',
     fontStyle: 'unset',
     textTransform: 'unset',
+    color: 'inherit',
   },
 
   'text-lead': {

--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -3,6 +3,19 @@
   "name": "elvis",
   "content": [
     {
+      "version": "20.2.1",
+      "date": "September 05, 2024",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": [
+            "Removed redundant color declaration and rather let the components inherit their text color from the class .e-color-background-1."
+          ],
+          "components": [{ "displayName": "Typography", "url": "https://design.elvia.io/brand/typography" }]
+        }
+      ]
+    },
+    {
       "version": "20.2.0",
       "date": "September 03, 2024",
       "changelog": [

--- a/packages/elvis/src/components/alert.scss
+++ b/packages/elvis/src/components/alert.scss
@@ -48,7 +48,7 @@
     align-self: center;
 
     @include mixins.typography('text-md-strong');
-    color: var(--e-color-text-1);
+
     margin: 0;
   }
 
@@ -57,7 +57,7 @@
     align-self: center;
 
     @include mixins.typography('text-md');
-    color: var(--e-color-text-1);
+
     margin: 0;
   }
 
@@ -97,12 +97,10 @@
 
     .e-alert__title {
       @include mixins.typography('text-sm-strong');
-      color: var(--e-color-text-1);
     }
 
     .e-alert__text {
       @include mixins.typography('text-sm');
-      color: var(--e-color-text-1);
     }
 
     .e-alert__actions,
@@ -131,7 +129,7 @@
 
   .e-alert__title {
     @include mixins.typography('title-xs');
-    color: var(--e-color-text-1);
+
     margin: 0 0 2px;
   }
 

--- a/packages/elvis/src/components/alert.scss
+++ b/packages/elvis/src/components/alert.scss
@@ -48,7 +48,7 @@
     align-self: center;
 
     @include mixins.typography('text-md-strong');
-
+    color: var(--e-color-text-1);
     margin: 0;
   }
 
@@ -57,7 +57,7 @@
     align-self: center;
 
     @include mixins.typography('text-md');
-
+    color: var(--e-color-text-1);
     margin: 0;
   }
 
@@ -97,10 +97,12 @@
 
     .e-alert__title {
       @include mixins.typography('text-sm-strong');
+      color: var(--e-color-text-1);
     }
 
     .e-alert__text {
       @include mixins.typography('text-sm');
+      color: var(--e-color-text-1);
     }
 
     .e-alert__actions,
@@ -129,7 +131,7 @@
 
   .e-alert__title {
     @include mixins.typography('title-xs');
-
+    color: var(--e-color-text-1);
     margin: 0 0 2px;
   }
 

--- a/packages/elvis/src/components/alert.scss
+++ b/packages/elvis/src/components/alert.scss
@@ -97,12 +97,10 @@
 
     .e-alert__title {
       @include mixins.typography('text-sm-strong');
-      color: var(--e-color-text-1);
     }
 
     .e-alert__text {
       @include mixins.typography('text-sm');
-      color: var(--e-color-text-1);
     }
 
     .e-alert__actions,
@@ -131,7 +129,6 @@
 
   .e-alert__title {
     @include mixins.typography('title-xs');
-    color: var(--e-color-text-1);
     margin: 0 0 2px;
   }
 

--- a/packages/elvis/src/components/button/button.scss
+++ b/packages/elvis/src/components/button/button.scss
@@ -21,6 +21,7 @@
   border: 1px solid var(--e-color-border-1);
   border-radius: 24px;
   background: var(--e-color-background-element-5);
+  color: var(--e-color-text-1);
 
   @include mixins.typography('text-interactive-md');
   color: var(--e-color-text-4);

--- a/packages/elvis/src/components/button/tertiary.scss
+++ b/packages/elvis/src/components/button/tertiary.scss
@@ -7,6 +7,7 @@
   border-radius: 0;
   border-bottom: 3px solid transparent;
   background: none;
+  color: var(--e-color-text-1);
 
   // Icons
   .e-btn__icon {
@@ -35,6 +36,7 @@
   @include buttonHelper.hover() {
     border-color: var(--e-color-border-hover-1);
     background: none;
+    color: inherit;
 
     .e-btn__icon > * {
       visibility: unset;
@@ -45,6 +47,7 @@
     padding-bottom: 6px;
     border-bottom: 2px solid var(--e-color-border-hover-1);
     background: none;
+    color: inherit;
 
     &.e-btn--lg {
       padding-bottom: 4px;

--- a/packages/elvis/src/components/button/tertiary.scss
+++ b/packages/elvis/src/components/button/tertiary.scss
@@ -7,7 +7,6 @@
   border-radius: 0;
   border-bottom: 3px solid transparent;
   background: none;
-  color: var(--e-color-text-1);
 
   // Icons
   .e-btn__icon {
@@ -36,7 +35,6 @@
   @include buttonHelper.hover() {
     border-color: var(--e-color-border-hover-1);
     background: none;
-    color: var(--e-color-text-1);
 
     .e-btn__icon > * {
       visibility: unset;
@@ -47,7 +45,6 @@
     padding-bottom: 6px;
     border-bottom: 2px solid var(--e-color-border-hover-1);
     background: none;
-    color: var(--e-color-text-1);
 
     &.e-btn--lg {
       padding-bottom: 4px;

--- a/packages/elvis/src/components/form/checkbox.scss
+++ b/packages/elvis/src/components/form/checkbox.scss
@@ -47,7 +47,7 @@ $checkbox-mark-border-checked: 1px solid var(--e-checkbox-border-checked-color);
   &__label {
     width: fit-content;
     margin-left: 8px;
-    color: var(--e-color-text-1);
+
     @include mixins.typography('text-md');
     line-height: 24px;
   }
@@ -120,7 +120,7 @@ $checkbox-mark-border-checked: 1px solid var(--e-checkbox-border-checked-color);
 
     .e-checkbox__label {
       @include mixins.typography('text-sm');
-      color: var(--e-color-text-1);
+
       line-height: 16px;
     }
 

--- a/packages/elvis/src/components/form/field.scss
+++ b/packages/elvis/src/components/form/field.scss
@@ -14,7 +14,7 @@
     @include mixins.typography('text-md-strong');
     display: block;
     margin-bottom: 4px;
-    color: var(--e-color-text-1);
+
     line-height: 22px;
     text-align: left;
 
@@ -30,7 +30,6 @@
     align-items: center;
     margin-top: 2px;
     @include mixins.typography('text-sm');
-    color: var(--e-color-text-1);
 
     visibility: hidden;
 

--- a/packages/elvis/src/components/form/fileupload.scss
+++ b/packages/elvis/src/components/form/fileupload.scss
@@ -20,7 +20,6 @@
 
   &__description {
     @include mixins.typography('text-medium');
-    color: var(--e-color-text-1);
   }
 
   &__input {
@@ -37,7 +36,7 @@
       border-radius: 0;
       border-bottom: 2.5px solid transparent;
       @include mixins.typography('text-interactive-md');
-      color: var(--e-color-text-1);
+
       cursor: pointer;
 
       @include helpers.hover() {

--- a/packages/elvis/src/components/form/fileupload.scss
+++ b/packages/elvis/src/components/form/fileupload.scss
@@ -9,6 +9,7 @@
   border: 2px dashed var(--e-color-border-3);
   border-radius: 4px;
   gap: 8px;
+  color: var(--e-color-text-1);
 
   &__icon,
   &__description,

--- a/packages/elvis/src/components/form/input.scss
+++ b/packages/elvis/src/components/form/input.scss
@@ -40,7 +40,6 @@
     border-radius: 2px;
     margin: 0;
     background: transparent;
-    color: var(--e-color-text-1);
   }
 
   > textarea {

--- a/packages/elvis/src/components/form/input.scss
+++ b/packages/elvis/src/components/form/input.scss
@@ -27,6 +27,7 @@
   background: var(--e-color-background-element-1);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   text-align: left;
+  color: var(--e-color-text-1);
 
   > input,
   > textarea {

--- a/packages/elvis/src/components/form/input.scss
+++ b/packages/elvis/src/components/form/input.scss
@@ -27,8 +27,6 @@
   background: var(--e-color-background-element-1);
   box-shadow: inset 0 0 0 var(--border-width) var(--border-color);
   text-align: left;
-  color: var(--e-color-text-1);
-
   > input,
   > textarea {
     @include mixins.typography('text-option');
@@ -41,6 +39,7 @@
     border-radius: 2px;
     margin: 0;
     background: transparent;
+    color: var(--e-color-text-1);
   }
 
   > textarea {

--- a/packages/elvis/src/components/form/radiobutton.scss
+++ b/packages/elvis/src/components/form/radiobutton.scss
@@ -49,7 +49,7 @@ $radio-mark-border: 1px solid var(--e-color-border-1);
     flex-grow: 1;
     margin-left: 32px;
     @include mixins.typography('text-md');
-    color: var(--e-color-text-1);
+
     line-height: 24px;
   }
 

--- a/packages/elvis/src/components/form/toggle.scss
+++ b/packages/elvis/src/components/form/toggle.scss
@@ -26,7 +26,7 @@ $toggle-slider-margin: calc((#{$toggle-height} - #{$toggle-slider-size}) / 2);
   display: flex;
   flex-direction: row;
   align-items: center;
-  color: var(--e-color-text-1);
+
   cursor: pointer;
   gap: 8px;
 

--- a/packages/elvis/src/components/link.scss
+++ b/packages/elvis/src/components/link.scss
@@ -15,7 +15,6 @@ $link-jumbo-phone-width: 287px;
   display: inline;
   box-sizing: border-box;
   border-bottom: 2px solid var(--e-color-border-1);
-  color: var(--e-color-text-1);
 
   @include mixins.typography('text-interactive-md');
 

--- a/packages/elvis/src/components/link.scss
+++ b/packages/elvis/src/components/link.scss
@@ -15,6 +15,7 @@ $link-jumbo-phone-width: 287px;
   display: inline;
   box-sizing: border-box;
   border-bottom: 2px solid var(--e-color-border-1);
+  color: var(--e-color-text-1);
 
   @include mixins.typography('text-interactive-md');
 

--- a/packages/elvis/src/components/link.scss
+++ b/packages/elvis/src/components/link.scss
@@ -17,7 +17,6 @@ $link-jumbo-phone-width: 287px;
   border-bottom: 2px solid var(--e-color-border-1);
 
   @include mixins.typography('text-interactive-md');
-  color: var(--e-color-text-1);
 
   cursor: pointer;
   font-weight: 700;
@@ -47,19 +46,19 @@ $link-jumbo-phone-width: 287px;
 
   &.e-link--lg {
     @include mixins.typography('text-interactive-lg');
-    color: var(--e-color-text-1);
+
     font-weight: 700;
   }
 
   &.e-link--md {
     @include mixins.typography('text-interactive-md');
-    color: var(--e-color-text-1);
+
     font-weight: 700;
   }
 
   &.e-link--sm {
     @include mixins.typography('text-interactive-sm');
-    color: var(--e-color-text-1);
+
     font-weight: 700;
   }
 
@@ -144,7 +143,7 @@ $link-jumbo-phone-width: 287px;
 
     &.e-link--lg {
       @include mixins.typography('text-interactive-lg');
-      color: var(--e-color-text-1);
+
       font-weight: 700;
 
       .e-link__icon {
@@ -154,7 +153,7 @@ $link-jumbo-phone-width: 287px;
 
     &.e-link--md {
       @include mixins.typography('text-interactive-lg');
-      color: var(--e-color-text-1);
+
       font-weight: 700;
 
       .e-link__icon {
@@ -164,7 +163,7 @@ $link-jumbo-phone-width: 287px;
 
     &.e-link--sm {
       @include mixins.typography('text-interactive-md');
-      color: var(--e-color-text-1);
+
       font-weight: 700;
 
       .e-link__icon {

--- a/packages/elvis/src/components/list.scss
+++ b/packages/elvis/src/components/list.scss
@@ -19,7 +19,7 @@
   flex-direction: column;
   padding-left: get-text-offset(var(--list-marker-dot-size));
   margin: 0.5rem 0;
-  color: var(--e-color-text-1);
+
   font-family: 'Red Hat Text', Verdana, sans-serif;
   gap: 8px;
   line-height: var(--list-line-height);

--- a/packages/elvis/src/components/table.scss
+++ b/packages/elvis/src/components/table.scss
@@ -19,7 +19,7 @@ $table-invalid-padding: 8px 16px;
   th {
     border-bottom: 1px solid var(--e-color-border-2);
     background: var(--e-color-background-element-6) !important;
-    color: var(--e-color-text-1);
+
     font-weight: 700;
   }
 }
@@ -90,7 +90,6 @@ $table-invalid-padding: 8px 16px;
 
     th,
     td {
-      color: var(--e-color-text-1);
       text-align: left;
     }
   }
@@ -199,7 +198,6 @@ $table-invalid-padding: 8px 16px;
 
       th {
         @include mixins.typography('title-xxs');
-        color: var(--e-color-text-1);
       }
     }
 
@@ -211,7 +209,6 @@ $table-invalid-padding: 8px 16px;
     th {
       @include mixins.typography('text-sm');
       padding: $table-small-padding;
-      color: var(--e-color-text-1);
     }
   }
 
@@ -259,13 +256,11 @@ $table-invalid-padding: 8px 16px;
 
     th,
     td {
-      color: var(--e-color-text-1);
       text-align: left;
     }
 
     th {
       @include mixins.typography('title-xs');
-      color: var(--e-color-text-1);
     }
   }
 
@@ -273,7 +268,7 @@ $table-invalid-padding: 8px 16px;
   td {
     @include mixins.typography('text-md');
     padding: $table-padding;
-    color: var(--e-color-text-1);
+
     text-align: left;
 
     @include breakpoints.breakpoint-up(Mobile) {
@@ -325,12 +320,10 @@ $table-invalid-padding: 8px 16px;
     th {
       @include mixins.typography('text-sm');
       padding: $table-small-padding;
-      color: var(--e-color-text-1);
     }
 
     tbody tr:first-of-type th {
       @include mixins.typography('text-sm-strong');
-      color: var(--e-color-text-1);
     }
   }
 

--- a/packages/elvis/src/components/tag.scss
+++ b/packages/elvis/src/components/tag.scss
@@ -50,7 +50,7 @@ $tag-colors: (
   border-radius: 4px;
   background: var(--e-color-background-element-3);
   @include mixins.typography('text-micro');
-  color: var(--e-color-text-1);
+
   letter-spacing: 0.5px;
   text-transform: uppercase;
   white-space: nowrap;

--- a/packages/elvis/src/utilities/mixins.scss
+++ b/packages/elvis/src/utilities/mixins.scss
@@ -28,7 +28,6 @@ $typography: TypographyMap.$typography;
 }
 
 @mixin typography($name) {
-  color: getValue($name, color);
   font-family: getValue($name, family);
   font-size: getValue($name, size);
   font-style: getValue($name, style);

--- a/packages/elvis/src/utilities/typography.scss
+++ b/packages/elvis/src/utilities/typography.scss
@@ -5,9 +5,12 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,400..900;1,500&family=Red+Hat+Mono&family=Red+Hat+Text:ital,wght@0,300..700;1,400..500&display=swap');
 
+html {
+  color: var(--e-color-text-primary, #000);
+}
+
 body {
   @include mixins.typography('text-md');
-  color: var(--e-color-text-primary, #000);
 }
 
 @each $label, $map in TypographyMap.$typography {

--- a/packages/elvis/src/utilities/typography.scss
+++ b/packages/elvis/src/utilities/typography.scss
@@ -5,10 +5,6 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,400..900;1,500&family=Red+Hat+Mono&family=Red+Hat+Text:ital,wght@0,300..700;1,400..500&display=swap');
 
-html {
-  color: var(--e-color-text-primary, #000);
-}
-
 body {
   @include mixins.typography('text-md');
 }


### PR DESCRIPTION
Remove color attribute on typography.scss from body tag. Add color attribute to html tag. Remove color from @mixin in mixins.scss. Remove all instances of color: 'inherit' in elviaTypography.ts

## Describe PR briefly:
