### PR TITLE
Add automatic language detection for aria-labels

### DIFF
--- a/packages/components/components/elvis-progress-linear/CHANGELOG.json
+++ b/packages/components/components/elvis-progress-linear/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-progress-linear",
   "content": [
     {
+      "date": "17.09.24",
+      "version": "2.6.0",
+      "changelog": [
+        {
+          "type": "new_feature",
+          "changes": [
+            "Added automatic support for switching aria-labels based on the global lang attribute on the html-element"
+          ]
+        }
+      ]
+    },
+    {
       "date": "30.05.24",
       "version": "2.5.2",
       "changelog": [

--- a/packages/components/components/elvis-progress-linear/package.json
+++ b/packages/components/components/elvis-progress-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-progress-linear",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/progressbar",
   "repository": {
@@ -18,7 +18,7 @@
   "dependencies": {
     "@elvia/elvis-colors": "^4.4.1",
     "@elvia/elvis-component-wrapper": "^4.2.0",
-    "@elvia/elvis-toolbox": "^12.0.1",
+    "@elvia/elvis-toolbox": "^12.1.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5"
   },

--- a/packages/components/components/elvis-progress-linear/src/react/elvia-progress-linear.tsx
+++ b/packages/components/components/elvis-progress-linear/src/react/elvia-progress-linear.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react';
+import { useLanguage } from '@elvia/elvis-toolbox';
+import React, { FC, useEffect, useState } from 'react';
 
 import { ProgressLinearProps } from './elvia-progress-linear.types';
 import { ProgressLinearProgress, ProgressLinearWrapper } from './styledComponents';
@@ -17,6 +18,17 @@ export const ProgressLinear: FC<ProgressLinearProps> = ({
   inlineStyle,
   ...rest
 }) => {
+  const lang = useLanguage();
+  const [computedAriaLabel, setAriaLabel] = useState('');
+  const [computedAriaValueText, setAriaValueText] = useState('');
+
+  useEffect(() => {
+    const newAriaLabel = lang === 'no' ? 'Progresjon' : 'Progress';
+    const newAriaValueLabel = lang === 'no' ? 'Progresjonen er nå på ' : 'The progress is now at ';
+    setAriaLabel(newAriaLabel);
+    setAriaValueText(newAriaValueLabel + value + '%.');
+  }, [lang, value]);
+
   return (
     <ProgressLinearWrapper
       $size={size}
@@ -27,8 +39,8 @@ export const ProgressLinear: FC<ProgressLinearProps> = ({
       aria-valuemax={100}
       role={ariaRole}
       id={componentId}
-      aria-label={ariaLabel ?? 'Progresjon'}
-      aria-valuetext={ariaValueText ?? 'Progresjonen er nå på ' + value + '%.'}
+      aria-label={ariaLabel ?? computedAriaLabel}
+      aria-valuetext={ariaValueText ?? computedAriaValueText}
       className={className ?? ''}
       {...rest}
     >

--- a/packages/components/components/elvis-slider/CHANGELOG.json
+++ b/packages/components/components/elvis-slider/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-slider",
   "content": [
     {
+      "date": "17.09.24",
+      "version": "5.1.0",
+      "changelog": [
+        {
+          "type": "new_feature",
+          "changes": [
+            "Added automatic support for switching aria-labels based on the global lang attribute on the html-element"
+          ]
+        }
+      ]
+    },
+    {
       "date": "25.06.24",
       "version": "5.0.3",
       "changelog": [

--- a/packages/components/components/elvis-slider/package.json
+++ b/packages/components/components/elvis-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-slider",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/slider",
   "repository": {
@@ -19,7 +19,7 @@
     "@elvia/elvis-assets-icons": "^3.10.0",
     "@elvia/elvis-colors": "^4.4.1",
     "@elvia/elvis-component-wrapper": "^4.2.0",
-    "@elvia/elvis-toolbox": "^12.0.1",
+    "@elvia/elvis-toolbox": "^12.1.0",
     "@elvia/elvis-typography": "^2.7.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5"

--- a/packages/components/components/elvis-slider/src/react/elvia-slider.tsx
+++ b/packages/components/components/elvis-slider/src/react/elvia-slider.tsx
@@ -4,6 +4,7 @@ import {
   FormFieldInputSuffixText,
   useInputModeDetection,
 } from '@elvia/elvis-toolbox';
+import { useLanguage } from '@elvia/elvis-toolbox';
 import React, { useEffect, useState } from 'react';
 
 import { BothSliders, ErrorType, FormFieldInputValue, Side, SliderProps } from './elvia-slider.types';
@@ -24,7 +25,7 @@ import {
 import { Tooltip } from './tooltip/tooltip';
 import { calculateHintReplacement } from './utils/calculateHintReplacement';
 import { calculateThumbPosition } from './utils/calculateThumbPosition';
-import { getAriaLabel } from './utils/getAriaLabel';
+import { getAriaLabel, getFormFieldLabel } from './utils/getAriaLabel';
 import {
   getAriaErrorMessage,
   getHasErrorPlaceholder,
@@ -89,6 +90,8 @@ export const Slider: React.FC<SliderProps> = function ({
 
   const { inputMode } = useInputModeDetection();
   const thumbWidth = inputMode === 'touch' ? 28 : 20;
+
+  const lang = useLanguage();
 
   const leftThumbPosition = calculateThumbPosition({
     side: 'left',
@@ -325,6 +328,7 @@ export const Slider: React.FC<SliderProps> = function ({
             ariaLabel,
             label,
             unit,
+            lang,
           })}
           aria-valuemax={max}
           aria-valuemin={min}
@@ -354,6 +358,7 @@ export const Slider: React.FC<SliderProps> = function ({
                 ariaLabel,
                 label,
                 unit,
+                lang,
               })}
               type={'range'}
               role={'slider'}
@@ -424,7 +429,7 @@ export const Slider: React.FC<SliderProps> = function ({
             isFullWidth={hintValueHasBeenReplaced || isFullWidthRangeInput}
             hasErrorPlaceholder={hasErrorPlaceholder && !(type === 'range' && isFullWidthRangeInput)}
           >
-            <FormFieldLabel>{label ? label : 'juster glidebryter'}</FormFieldLabel>
+            <FormFieldLabel>{getFormFieldLabel(label, lang)}</FormFieldLabel>
             <FormFieldInputContainer
               style={{
                 width:
@@ -481,7 +486,7 @@ export const Slider: React.FC<SliderProps> = function ({
             hasErrorPlaceholder={hasErrorPlaceholder}
             isFullWidth={isFullWidthRangeInput}
           >
-            <FormFieldLabel>{label ? label : 'juster glidebryter'}</FormFieldLabel>
+            <FormFieldLabel>{getFormFieldLabel(label, lang)}</FormFieldLabel>
             <FormFieldInputContainer
               style={{
                 width:

--- a/packages/components/components/elvis-slider/src/react/utils/getAriaLabel.ts
+++ b/packages/components/components/elvis-slider/src/react/utils/getAriaLabel.ts
@@ -1,3 +1,5 @@
+import { LanguageCode } from '@elvia/elvis-toolbox/src/hooks/useLanguage';
+
 import { BothSliders, Side, SliderProps, SliderType } from '../elvia-slider.types';
 
 export const getAriaLabel = ({
@@ -7,6 +9,7 @@ export const getAriaLabel = ({
   ariaLabel,
   label,
   unit,
+  lang,
 }: {
   side: Side;
   sliderValue: BothSliders<number>;
@@ -14,15 +17,20 @@ export const getAriaLabel = ({
   ariaLabel?: SliderProps['ariaLabel'];
   label?: string;
   unit?: string;
+  lang: LanguageCode;
 }): string => {
   if (ariaLabel) {
-    return returnAriaLabelFromProp(side, ariaLabel);
+    return returnAriaLabelFromProp(side, ariaLabel, lang);
   } else {
-    return generateAutomaticAriaLabel(side, type, sliderValue, label, unit);
+    return generateAutomaticAriaLabel(side, type, sliderValue, lang, label, unit);
   }
 };
 
-const returnAriaLabelFromProp = (side: Side, ariaLabel: SliderProps['ariaLabel']): string => {
+const returnAriaLabelFromProp = (
+  side: Side,
+  ariaLabel: SliderProps['ariaLabel'],
+  lang: LanguageCode,
+): string => {
   if (typeof ariaLabel === 'object') {
     return ariaLabel[side];
   }
@@ -31,24 +39,35 @@ const returnAriaLabelFromProp = (side: Side, ariaLabel: SliderProps['ariaLabel']
     return ariaLabel;
   }
 
-  return 'Glidebryter';
+  if (lang === 'no') {
+    return 'Glidebryter';
+  } else {
+    return 'Slider';
+  }
 };
 
 const generateAutomaticAriaLabel = (
   side: Side,
   type: SliderType,
   sliderValue: BothSliders<number>,
+  lang: LanguageCode,
   label?: string,
   unit?: string,
 ): string => {
-  let newAriaLabel = 'Glidebryter';
+  let newAriaLabel = lang === 'no' ? 'Glidebryter' : 'Slider';
 
   if (type === 'range') {
-    const prefix = side === 'left' ? 'Startverdi' : 'Sluttverdi';
+    if (lang === 'no') {
+      const prefix = side === 'left' ? 'Startverdi' : 'Sluttverdi';
 
-    newAriaLabel = `${prefix} ${label ?? ''} rekkeviddeglidebryter ${
-      unit ? ' med verdi ' + sliderValue[side] + unit : ''
-    }`;
+      newAriaLabel = `${prefix} ${label ?? ''} rekkeviddeglidebryter ${
+        unit ? ' med verdi ' + sliderValue[side] + unit : ''
+      }`;
+    } else {
+      const prefix = side === 'left' ? 'Startvalue' : 'Endvalue';
+
+      newAriaLabel = `${prefix} ${label ?? ''} range slider ${unit ? ' with value ' + sliderValue[side] + unit : ''}`;
+    }
   }
 
   if (type === 'simple' && (label || unit)) {
@@ -56,4 +75,14 @@ const generateAutomaticAriaLabel = (
   }
 
   return newAriaLabel.replace(/\s+/g, ' ').trim();
+};
+
+export const getFormFieldLabel = (label: string | undefined, lang: LanguageCode): string => {
+  if (label) {
+    return label;
+  } else if (lang === 'no') {
+    return 'juster glidebryter';
+  } else {
+    return 'adjust slider';
+  }
 };


### PR DESCRIPTION
Added automatic support for switching aria-label language based on global lang attribute in html element for both elvia-progress-linear and elvia-slider components.

# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [X] Bumpet package?
- [X] Updated changelog?
- [X] Correct date in changelog?

## Describe PR briefly:
Added automatic support for switching aria-labels based on the global lang attribute on the html-element for two components:
- Slider
- Progress-Linear
