### PR TITLE
LEGO-3662 Chip – legge på type="button" på chips

### DIFF
--- a/packages/components/components/elvis-accordion/CHANGELOG.json
+++ b/packages/components/components/elvis-accordion/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-accordion",
   "content": [
     {
+      "date": "18.09.24",
+      "version": "3.2.8",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": [
+            "Explicitly set the <code>type</code> of the button inside the accordion to <code>'button'</code> to avoid issues with form submission."
+          ]
+        }
+      ]
+    },
+    {
       "date": "31.05.24",
       "version": "3.2.7",
       "changelog": [

--- a/packages/components/components/elvis-accordion/package.json
+++ b/packages/components/components/elvis-accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-accordion",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/accordion",
   "repository": {

--- a/packages/components/components/elvis-accordion/src/react/elvia-accordion.tsx
+++ b/packages/components/components/elvis-accordion/src/react/elvia-accordion.tsx
@@ -152,6 +152,7 @@ export const Accordion: FC<AccordionProps> = ({
           onMouseLeave={() => setIsHoveringButton(false)}
           aria-label={decideButtonAriaLabel()}
           reverseLayout={isStartAligned && !isFullWidth}
+          type="button"
         >
           <AccordionLabel hasLabel={type !== 'single'} isFullWidth={isFullWidth}>
             {isOpenState ? (

--- a/packages/components/components/elvis-carousel/CHANGELOG.json
+++ b/packages/components/components/elvis-carousel/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-carousel",
   "content": [
     {
+      "date": "18.09.24",
+      "version": "3.1.6",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": [
+            "Explicitly set the <code>type</code> of the buttons inside the carousel to <code>'button'</code> to avoid issues with form submission."
+          ]
+        }
+      ]
+    },
+    {
       "date": "30.05.24",
       "version": "3.1.5",
       "changelog": [

--- a/packages/components/components/elvis-carousel/package.json
+++ b/packages/components/components/elvis-carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-carousel",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/carousel",
   "repository": {

--- a/packages/components/components/elvis-carousel/src/react/elvia-carousel.tsx
+++ b/packages/components/components/elvis-carousel/src/react/elvia-carousel.tsx
@@ -253,6 +253,7 @@ export const Carousel: FC<CarouselProps> = function ({
           onMouseEnter={() => setIsHoveringLeftButton(true)}
           onMouseLeave={() => setIsHoveringLeftButton(false)}
           data-testid="carousel-left-arrow"
+          type="button"
         >
           <IconWrapper
             icon={isHoveringLeftButton ? arrowLeftCircleFilledColor : arrowLeftCircleColor}
@@ -273,6 +274,7 @@ export const Carousel: FC<CarouselProps> = function ({
                 listIndex !== index &&
                 handleValueChange(listIndex, listIndex > index ? 'right' : 'left', true)
               }
+              type="button"
             />
           ))}
         </CarouselListOfDots>
@@ -284,6 +286,7 @@ export const Carousel: FC<CarouselProps> = function ({
             onMouseEnter={() => setIsHoveringRightButton(true)}
             onMouseLeave={() => setIsHoveringRightButton(false)}
             data-testid="carousel-onboarding-checkmark"
+            type="button"
           >
             <IconWrapper icon={isHoveringRightButton ? checkCircleFilledColor : checkCircleColor} size="md" />
           </CarouselCheckButton>
@@ -297,6 +300,7 @@ export const Carousel: FC<CarouselProps> = function ({
             onMouseEnter={() => setIsHoveringRightButton(true)}
             onMouseLeave={() => setIsHoveringRightButton(false)}
             data-testid="carousel-right-arrow"
+            type="button"
           >
             <IconWrapper
               icon={isHoveringRightButton ? arrowRightCircleFilledColor : arrowRightCircleColor}

--- a/packages/components/components/elvis-chip/src/react/elvia-chip.tsx
+++ b/packages/components/components/elvis-chip/src/react/elvia-chip.tsx
@@ -68,6 +68,7 @@ export const Chip: FC<ChipProps> = ({
       isLoading={isLoading}
       style={inlineStyle}
       disabled={isDisabled}
+      type="button"
       data-testid="chip-button"
       {...rest}
     >

--- a/packages/components/components/elvis-datepicker/src/react/yearPicker/yearPicker.tsx
+++ b/packages/components/components/elvis-datepicker/src/react/yearPicker/yearPicker.tsx
@@ -101,12 +101,13 @@ export const YearPicker: React.FC<Props> = ({ selectedDate, onYearChange, minDat
       <ScrollContainer ref={scrollContainer} tabIndex={0} onKeyDown={handleKeyDown}>
         {years.map((year, index) => (
           <YearButton
-            tabIndex={-1}
-            key={year.year}
+            disabled={year.isDisabled}
             isActive={year.isActive}
             isFocused={focusedYearIndex === index}
+            key={year.year}
             onClick={() => onYearChange(year.year)}
-            disabled={year.isDisabled}
+            tabIndex={-1}
+            type="button"
           >
             {year.year}
           </YearButton>

--- a/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
+++ b/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
@@ -59,9 +59,10 @@ export const ThemePicker: React.FC<ThemePickerProps> = ({ onThemeChange }) => {
       <ThemeListContainer>
         {themes.map((pickerTheme) => (
           <ThemeButton
-            key={pickerTheme.theme}
             isActive={currentTheme === pickerTheme.theme}
+            key={pickerTheme.theme}
             onClick={() => changeTheme(pickerTheme.theme)}
+            type="button"
           >
             <ThemeIconOutline>
               {pickerTheme.theme === 'dark' && <DarkThemeIcon />}

--- a/packages/components/components/elvis-pagination/CHANGELOG.json
+++ b/packages/components/components/elvis-pagination/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-pagination",
   "content": [
     {
+      "date": "28.09.24",
+      "version": "3.6.1",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": [
+            "Explicitly set the <code>type</code> of the buttons inside the pagination to <code>'button'</code> to avoid issues with form submission."
+          ]
+        }
+      ]
+    },
+    {
       "date": "17.09.24",
       "version": "3.6.0",
       "changelog": [

--- a/packages/components/components/elvis-pagination/package.json
+++ b/packages/components/components/elvis-pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-pagination",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/pagination",
   "repository": {

--- a/packages/components/components/elvis-pagination/src/react/elvia-pagination.tsx
+++ b/packages/components/components/elvis-pagination/src/react/elvia-pagination.tsx
@@ -193,10 +193,11 @@ export const Pagination: FC<PaginationProps> = function ({
       {showPaginationNumbers() && (
         <PaginatorSelectorArea ref={listContainerRef}>
           <PaginatorSelectorArrowBtn
-            visible={previousEnabled}
             aria-hidden={!previousEnabled}
-            onClick={handleOnPreviousPageClick}
             aria-label={lang === 'no' ? 'Forrige side' : 'Previous page'}
+            onClick={handleOnPreviousPageClick}
+            type="button"
+            visible={previousEnabled}
           >
             <IconWrapper icon={arrowLongLeft} size="xs" />
           </PaginatorSelectorArrowBtn>
@@ -209,10 +210,11 @@ export const Pagination: FC<PaginationProps> = function ({
             lastNumberLimit={lastNumberLimit}
           />
           <PaginatorSelectorArrowBtn
-            visible={nextEnabled}
             aria-hidden={!nextEnabled}
-            onClick={handleOnNextPageClick}
             aria-label={lang === 'no' ? 'Neste side' : 'Next page'}
+            onClick={handleOnNextPageClick}
+            type="button"
+            visible={nextEnabled}
           >
             <IconWrapper icon={arrowLongRight} size="xs" />
           </PaginatorSelectorArrowBtn>

--- a/packages/components/components/elvis-tabs/CHANGELOG.json
+++ b/packages/components/components/elvis-tabs/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-tabs",
   "content": [
     {
+      "date": "18.09.24",
+      "version": "2.2.6",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": [
+            "Explicitly set the <code>type</code> of the button inside the tabs to <code>'button'</code> to avoid issues with form submission."
+          ]
+        }
+      ]
+    },
+    {
       "date": "30.05.24",
       "version": "2.2.5",
       "changelog": [

--- a/packages/components/components/elvis-tabs/package.json
+++ b/packages/components/components/elvis-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-tabs",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/tabs",
   "repository": {

--- a/packages/components/components/elvis-tabs/src/react/elvia-tabs.tsx
+++ b/packages/components/components/elvis-tabs/src/react/elvia-tabs.tsx
@@ -90,14 +90,15 @@ export const Tabs: FC<TabsProps> = ({
         {items &&
           items.map((item, i) => (
             <Tab
-              role="tab"
-              id={uniqueId + i}
-              key={item}
-              aria-selected={selectedIndex === i}
               aria-controls={uniqueId + i}
-              onClick={(event) => onTabClick(i, event)}
-              isSelected={selectedIndex == i}
+              aria-selected={selectedIndex === i}
+              id={uniqueId + i}
               isInverted={isInverted ?? false}
+              isSelected={selectedIndex == i}
+              key={item}
+              onClick={(event) => onTabClick(i, event)}
+              role="tab"
+              type="button"
             >
               <BoldTabTextPlaceholder aria-hidden="true">{item}</BoldTabTextPlaceholder>
               <TabText>{item}</TabText>

--- a/packages/components/components/elvis-timepicker/src/react/popup/numberPicker.tsx
+++ b/packages/components/components/elvis-timepicker/src/react/popup/numberPicker.tsx
@@ -180,14 +180,15 @@ export const NumberPicker: React.FC<Props> = ({
         </ArrowButtonContainer>
         {loopedNumbers.map((number, index) => (
           <NumberButton
-            tabIndex={-1}
-            isSelected={number === currentValue}
+            aria-label={`${title} ${padDigit(number)}`}
+            data-id={`${title}-${padDigit(number)}`}
+            data-testid={`${title}-number-button`}
             isDisabled={isNumberDisabled(number)}
+            isSelected={number === currentValue}
             key={index}
             onClick={() => onSelect(timeUnit, number, isNumberDisabled(number))}
-            data-testid={`${title}-number-button`}
-            data-id={`${title}-${padDigit(number)}`}
-            aria-label={`${title} ${padDigit(number)}`}
+            tabIndex={-1}
+            type="button"
           >
             {padDigit(number)}
           </NumberButton>


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3662
This PR adds`type=button` to the buttons used in Chips as these are used inside a form in MDMx.

I also searched for other buttons in the design system ("`styled.button`") and set their type to "button" too, to avoid this issue again. I also did it in the Timepicker, Datepicker, and Header components even though we haven't experienced any problems with it, to keep it more consistent.