### PR TITLE
feat(badge): add `isHidden` prop

### DIFF
--- a/packages/components/components/elvis-badge/CHANGELOG.json
+++ b/packages/components/components/elvis-badge/CHANGELOG.json
@@ -3,6 +3,22 @@
   "name": "elvis-badge",
   "content": [
     {
+      "date": "18.09.24",
+      "version": "2.3.0",
+      "changelog": [
+        {
+          "type": "new_feature",
+          "changes": [
+            "Added the <code>isHidden</code> property to hide the badge. The badge remains in the DOM but is not visible. It will animate in and out when the property changes."
+          ]
+        },
+        {
+          "type": "patch",
+          "changes": ["Updated internal dependencies."]
+        }
+      ]
+    },
+    {
       "date": "26.06.24",
       "version": "2.2.0",
       "changelog": [

--- a/packages/components/components/elvis-badge/package.json
+++ b/packages/components/components/elvis-badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-badge",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/badge",
   "repository": {
@@ -16,9 +16,9 @@
     "dist"
   ],
   "dependencies": {
-    "@elvia/elvis-colors": "^4.4.1",
-    "@elvia/elvis-component-wrapper": "^4.2.0",
-    "@elvia/elvis-toolbox": "^12.0.2",
+    "@elvia/elvis-colors": "^4.4.2",
+    "@elvia/elvis-component-wrapper": "^4.3.0",
+    "@elvia/elvis-toolbox": "^12.1.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "classnames": "^2.5.1"

--- a/packages/components/components/elvis-badge/src/react/config.ts
+++ b/packages/components/components/elvis-badge/src/react/config.ts
@@ -4,7 +4,8 @@ export const config: ComponentConfig = {
   name: 'Badge',
   attributes: [
     { name: 'badgeColor', type: 'string' },
-    { name: 'count', type: 'number' },
     { name: 'content', type: 'string' },
+    { name: 'count', type: 'number' },
+    { name: 'isHidden', type: 'boolean' },
   ],
 };

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.module.scss
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.module.scss
@@ -20,10 +20,17 @@
   right: 0;
   top: 0;
   transform: translate(50%, -50%);
+  transform-origin: top right;
+  scale: 1;
   user-select: none;
   height: 16px;
   width: 16px;
   z-index: 10;
+  transition: scale 0.25s ease;
+}
+
+.badge--hidden {
+  scale: 0;
 }
 
 .badge--wide {

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.test.tsx
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.test.tsx
@@ -98,6 +98,27 @@ describe('Elvis Badge', () => {
     });
   });
 
+  describe('the hidden badge', () => {
+    beforeEach(() => {
+      render(
+        <Badge
+          count={101}
+          isHidden={true}
+          content={
+            <span className="e-btn__icon">
+              <i className="e-icon e-icon--upload" aria-hidden="true"></i>
+            </span>
+          }
+        />,
+      );
+    });
+
+    it('should not be visible', () => {
+      const badgeCircle = screen.getByRole('status');
+      expect(badgeCircle).toHaveClass('badge--hidden');
+    });
+  });
+
   describe('the accessibility', () => {
     it('should have no axe violations', async () => {
       render(

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.test.tsx
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.test.tsx
@@ -93,7 +93,7 @@ describe('Elvis Badge', () => {
     });
 
     it('should have a red contrast text color', () => {
-      const badgeCircle = screen.getByRole('status', { hidden: true });
+      const badgeCircle = screen.getByRole('status');
       expect(badgeCircle).toHaveClass('badge--red');
     });
   });
@@ -114,7 +114,7 @@ describe('Elvis Badge', () => {
     });
 
     it('should not be visible', () => {
-      const badgeCircle = screen.getByRole('status');
+      const badgeCircle = screen.getByRole('status', { hidden: true });
       expect(badgeCircle).toHaveClass('badge--hidden');
     });
   });

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.test.tsx
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.test.tsx
@@ -93,7 +93,7 @@ describe('Elvis Badge', () => {
     });
 
     it('should have a red contrast text color', () => {
-      const badgeCircle = screen.getByRole('status');
+      const badgeCircle = screen.getByRole('status', { hidden: true });
       expect(badgeCircle).toHaveClass('badge--red');
     });
   });

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.tsx
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.tsx
@@ -37,7 +37,7 @@ export const Badge: React.FC<BadgeProps> = ({
   return (
     <div className={classnames(className, styles['badge-container'])} style={{ ...inlineStyle }} {...rest}>
       <div ref={contentRef}>{content}</div>
-      <div className={badgeCircleClasses} role="status">
+      <div className={badgeCircleClasses} role="status" aria-hidden={isHidden}>
         {getCount(count)}
       </div>
     </div>

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.tsx
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.tsx
@@ -11,6 +11,7 @@ export const Badge: React.FC<BadgeProps> = ({
   content,
   count,
   inlineStyle,
+  isHidden = false,
   webcomponent,
   ...rest
 }) => {
@@ -30,6 +31,7 @@ export const Badge: React.FC<BadgeProps> = ({
 
   const badgeCircleClasses = classnames(styles['badge-circle'], styles[`badge--${badgeColor}`], {
     [styles['badge--wide']]: getCount(count) === '99+',
+    [styles['badge--hidden']]: isHidden,
   });
 
   return (

--- a/packages/components/components/elvis-badge/src/react/elvia-badge.types.tsx
+++ b/packages/components/components/elvis-badge/src/react/elvia-badge.types.tsx
@@ -8,6 +8,7 @@ export interface BaseBadgeProps extends BaseProps {
   badgeColor?: BadgeColor;
   content?: JSX.Element;
   count?: number | string;
+  isHidden?: boolean;
 }
 
 export interface BadgeProps extends BaseBadgeProps, Omit<ComponentPropsWithoutRef<'div'>, 'content'> {}

--- a/packages/web/src/app/dev/v2-playground/v2-playground.component.html
+++ b/packages/web/src/app/dev/v2-playground/v2-playground.component.html
@@ -2,7 +2,18 @@
 <div class="components-examples" id="dev-component-examples">
   <div class="example-wrapper">
     <!--Test the component here (delete what was here previously). When done add it to the list alphabetically-->
-    <div class="example-wrapper"></div>
+    <div class="example-wrapper">
+      <elvia-badge [count]="10" [isHidden]="isHidden">
+        <button
+          class="e-thumbnail"
+          aria-label="Thumbnail button that opens the image in a larger view"
+          slot="content"
+          (click)="isHidden = !isHidden"
+        >
+          <img src="https://picsum.photos/56" alt="Thumbnail example image" />
+        </button>
+      </elvia-badge>
+    </div>
 
     <!--Accordion-->
     <div class="example-wrapper">

--- a/packages/web/src/app/dev/v2-playground/v2-playground.component.ts
+++ b/packages/web/src/app/dev/v2-playground/v2-playground.component.ts
@@ -25,6 +25,7 @@ interface StepStates {
 export class v2PlaygroundComponent {
   endMinDate = new Date(2023, 9, 10);
   endTimeValue: Date | null = new Date(2023, 9, 10);
+  isHidden = false;
 
   testDate = () => {
     this.endMinDate = new Date(2023, 9, 12);

--- a/packages/web/src/app/doc-pages/components/badge-doc/badge-data.ts
+++ b/packages/web/src/app/doc-pages/components/badge-doc/badge-data.ts
@@ -21,5 +21,10 @@ export const badgeData: ComponentData<BaseBadgeProps> = {
       type: 'number | string | undefined',
       description: 'The number displayed inside the badge',
     },
+    isHidden: {
+      type: 'boolean',
+      description: 'Hides the badge',
+      default: 'false',
+    },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,9 +2370,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-badge@workspace:packages/components/components/elvis-badge"
   dependencies:
-    "@elvia/elvis-colors": "npm:^4.4.1"
-    "@elvia/elvis-component-wrapper": "npm:^4.2.0"
-    "@elvia/elvis-toolbox": "npm:^12.0.2"
+    "@elvia/elvis-colors": "npm:^4.4.2"
+    "@elvia/elvis-component-wrapper": "npm:^4.3.0"
+    "@elvia/elvis-toolbox": "npm:^12.1.0"
     "@emotion/react": "npm:^11.11.4"
     "@emotion/styled": "npm:^11.11.5"
     classnames: "npm:^2.5.1"
@@ -3122,7 +3122,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elvia/elvis-toolbox@npm:^12.0.1, @elvia/elvis-toolbox@npm:^12.0.2, @elvia/elvis-toolbox@npm:^12.0.3, @elvia/elvis-toolbox@npm:^12.0.5, @elvia/elvis-toolbox@npm:^12.0.6, @elvia/elvis-toolbox@npm:^12.1.0, @elvia/elvis-toolbox@workspace:packages/components/components/elvis-toolbox":
+"@elvia/elvis-toolbox@npm:^12.0.1, @elvia/elvis-toolbox@npm:^12.0.3, @elvia/elvis-toolbox@npm:^12.0.5, @elvia/elvis-toolbox@npm:^12.0.6, @elvia/elvis-toolbox@npm:^12.1.0, @elvia/elvis-toolbox@workspace:packages/components/components/elvis-toolbox":
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-toolbox@workspace:packages/components/components/elvis-toolbox"
   dependencies:


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
https://elvia.atlassian.net/browse/LEGO-3657?atlOrigin=eyJpIjoiZjgyMmU1MTU5ZTVhNGY4MzliMjZkYTJhZTVkN2QzOWMiLCJwIjoiaiJ9

This PR adds the `isHidden` prop. When it is `true`, the badge gets scaled down to 0.


https://github.com/user-attachments/assets/3b82365e-6006-4451-b372-7d5b1eaa6e32

