### PR TITLE
Lego 3647 komponenter stotte for custom aria labels pa desktopmenu mobilemenu

### DIFF
--- a/packages/components/components/elvis-header/CHANGELOG.json
+++ b/packages/components/components/elvis-header/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-header",
   "content": [
     {
+      "date": "01.10.24",
+      "version": "1.13.0",
+      "changelog": [
+        {
+          "type": "new_feature",
+          "changes": [
+            "Added automatic support for switching aria-labels based on the global lang attribute on the html-element."
+          ]
+        }
+      ]
+    },
+    {
       "date": "17.09.24",
       "version": "1.12.1",
       "changelog": [

--- a/packages/components/components/elvis-header/package.json
+++ b/packages/components/components/elvis-header/package.json
@@ -21,7 +21,7 @@
     "@elvia/elvis-assets-icons": "^3.11.1",
     "@elvia/elvis-colors": "^4.4.2",
     "@elvia/elvis-component-wrapper": "^4.2.0",
-    "@elvia/elvis-toolbox": "^12.0.6",
+    "@elvia/elvis-toolbox": "^12.1.0",
     "@elvia/elvis-typography": "^3.1.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5"

--- a/packages/components/components/elvis-header/src/react/desktopMenu/desktopMenu.tsx
+++ b/packages/components/components/elvis-header/src/react/desktopMenu/desktopMenu.tsx
@@ -31,6 +31,7 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
   onThemeChange,
   menuContent,
   webcomponent,
+  labels,
 }) => {
   const { trapFocus, releaseFocusTrap } = useFocusTrap();
   const connectedElementRef = useRef<HTMLButtonElement>(null);
@@ -66,7 +67,7 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
       <ProfileButton
         size="sm"
         onClick={() => togglePopupVisibility(!isShowing)}
-        aria-label="Åpne brukermeny"
+        aria-label={labels.openMenuLabel}
         aria-expanded={isShowing}
         aria-haspopup="dialog"
         aria-controls="ewc-header-desktop-menu"
@@ -94,7 +95,7 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
             <Footer>
               <TertiaryButton size="sm" onClick={onSignOutClick}>
                 <IconWrapper icon={logout} size="xs" />
-                Logg ut
+                {labels.logoutLabel}
               </TertiaryButton>
             </Footer>
           </MenuContainer>

--- a/packages/components/components/elvis-header/src/react/desktopMenu/desktopMenu.tsx
+++ b/packages/components/components/elvis-header/src/react/desktopMenu/desktopMenu.tsx
@@ -32,7 +32,6 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
   menuContent,
   webcomponent,
   labels,
-  lang,
 }) => {
   const { trapFocus, releaseFocusTrap } = useFocusTrap();
   const connectedElementRef = useRef<HTMLButtonElement>(null);
@@ -91,7 +90,7 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
               <Email>{email}</Email>
             </UserGrid>
             <DesktopMenuSlot ref={menuContentRef}>{menuContent}</DesktopMenuSlot>
-            {!hideThemeSwitch && <ThemePicker lang={lang} onThemeChange={onThemeChange} />}
+            {!hideThemeSwitch && <ThemePicker onThemeChange={onThemeChange} />}
             <MenuHr></MenuHr>
             <Footer>
               <TertiaryButton size="sm" onClick={onSignOutClick}>

--- a/packages/components/components/elvis-header/src/react/desktopMenu/desktopMenu.tsx
+++ b/packages/components/components/elvis-header/src/react/desktopMenu/desktopMenu.tsx
@@ -32,6 +32,7 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
   menuContent,
   webcomponent,
   labels,
+  lang,
 }) => {
   const { trapFocus, releaseFocusTrap } = useFocusTrap();
   const connectedElementRef = useRef<HTMLButtonElement>(null);
@@ -90,7 +91,7 @@ export const DesktopMenu: React.FC<UserMenuProps> = ({
               <Email>{email}</Email>
             </UserGrid>
             <DesktopMenuSlot ref={menuContentRef}>{menuContent}</DesktopMenuSlot>
-            {!hideThemeSwitch && <ThemePicker onThemeChange={onThemeChange} />}
+            {!hideThemeSwitch && <ThemePicker lang={lang} onThemeChange={onThemeChange} />}
             <MenuHr></MenuHr>
             <Footer>
               <TertiaryButton size="sm" onClick={onSignOutClick}>

--- a/packages/components/components/elvis-header/src/react/elvia-header.tsx
+++ b/packages/components/components/elvis-header/src/react/elvia-header.tsx
@@ -130,7 +130,6 @@ export const Header: React.FC<HeaderProps> = ({
               menuContent={menuContent}
               webcomponent={webcomponent}
               labels={labels}
-              lang={lang}
             />
           </SquareContainer>
         )}
@@ -147,7 +146,6 @@ export const Header: React.FC<HeaderProps> = ({
               menuContent={menuContent}
               webcomponent={webcomponent}
               labels={labels}
-              lang={lang}
             />
           </>
         )}

--- a/packages/components/components/elvis-header/src/react/elvia-header.tsx
+++ b/packages/components/components/elvis-header/src/react/elvia-header.tsx
@@ -130,6 +130,7 @@ export const Header: React.FC<HeaderProps> = ({
               menuContent={menuContent}
               webcomponent={webcomponent}
               labels={labels}
+              lang={lang}
             />
           </SquareContainer>
         )}
@@ -146,6 +147,7 @@ export const Header: React.FC<HeaderProps> = ({
               menuContent={menuContent}
               webcomponent={webcomponent}
               labels={labels}
+              lang={lang}
             />
           </>
         )}

--- a/packages/components/components/elvis-header/src/react/elvia-header.tsx
+++ b/packages/components/components/elvis-header/src/react/elvia-header.tsx
@@ -1,5 +1,5 @@
 import { getThemeColor } from '@elvia/elvis-colors';
-import { useBreakpoint, useSlot } from '@elvia/elvis-toolbox';
+import { useBreakpoint, useLanguage, useSlot } from '@elvia/elvis-toolbox';
 import React, { useEffect, useState } from 'react';
 
 import { AppDrawer } from './appDrawer/appDrawer';
@@ -66,6 +66,25 @@ export const Header: React.FC<HeaderProps> = ({
     setThemeClassOnDocument(getStoredActiveTheme());
   }, []);
 
+  const lang = useLanguage();
+
+  const labels =
+    lang === 'no'
+      ? {
+          openMenuLabel: 'Åpne brukermeny',
+          selectAppLabel: 'Velg applikasjon',
+          logoutLabel: 'Logg ut',
+          minimizeLabel: 'Minimer',
+          maximizeLabel: 'Maksimer',
+        }
+      : {
+          openMenuLabel: 'Open user menu',
+          selectAppLabel: 'Select application',
+          logoutLabel: 'Log out',
+          minimizeLabel: 'Minimize',
+          maximizeLabel: 'Maximize',
+        };
+
   return (
     <div className={className} style={{ ...inlineStyle }}>
       <StyledHeader>
@@ -110,6 +129,7 @@ export const Header: React.FC<HeaderProps> = ({
               onMenuToggle={(isOpen) => setMobileMenuIsOpen(isOpen)}
               menuContent={menuContent}
               webcomponent={webcomponent}
+              labels={labels}
             />
           </SquareContainer>
         )}
@@ -125,12 +145,14 @@ export const Header: React.FC<HeaderProps> = ({
               onThemeChange={themeChange}
               menuContent={menuContent}
               webcomponent={webcomponent}
+              labels={labels}
             />
           </>
         )}
       </StyledHeader>
       {hasNavItems && (
         <SideNav
+          labels={labels}
           ref={sidenavRef}
           onSideNavToggle={() => setSidenavIsExpanded(!sidenavIsExpanded)}
           isExpanded={sidenavIsExpanded}

--- a/packages/components/components/elvis-header/src/react/elviaHeader.types.tsx
+++ b/packages/components/components/elvis-header/src/react/elviaHeader.types.tsx
@@ -1,5 +1,5 @@
 import { ThemeName } from '@elvia/elvis-colors';
-import { BaseProps, LanguageCode } from '@elvia/elvis-toolbox';
+import { BaseProps } from '@elvia/elvis-toolbox';
 
 export type Theme = ThemeName | 'system';
 export const themeLocalStorageKey = 'elviaHeaderPreferredTheme';
@@ -22,7 +22,6 @@ export interface UserMenuProps {
   menuContent?: JSX.Element;
   webcomponent: BaseProps['webcomponent'];
   labels: Labels;
-  lang: LanguageCode;
 }
 
 export interface HeaderProps extends BaseProps {

--- a/packages/components/components/elvis-header/src/react/elviaHeader.types.tsx
+++ b/packages/components/components/elvis-header/src/react/elviaHeader.types.tsx
@@ -1,5 +1,5 @@
 import { ThemeName } from '@elvia/elvis-colors';
-import { BaseProps } from '@elvia/elvis-toolbox';
+import { BaseProps, LanguageCode } from '@elvia/elvis-toolbox';
 
 export type Theme = ThemeName | 'system';
 export const themeLocalStorageKey = 'elviaHeaderPreferredTheme';
@@ -22,6 +22,7 @@ export interface UserMenuProps {
   menuContent?: JSX.Element;
   webcomponent: BaseProps['webcomponent'];
   labels: Labels;
+  lang: LanguageCode;
 }
 
 export interface HeaderProps extends BaseProps {

--- a/packages/components/components/elvis-header/src/react/elviaHeader.types.tsx
+++ b/packages/components/components/elvis-header/src/react/elviaHeader.types.tsx
@@ -5,6 +5,14 @@ export type Theme = ThemeName | 'system';
 export const themeLocalStorageKey = 'elviaHeaderPreferredTheme';
 export type ThemeEvent = (themeName: Theme) => void;
 
+export interface Labels {
+  openMenuLabel: string;
+  selectAppLabel: string;
+  logoutLabel: string;
+  minimizeLabel: string;
+  maximizeLabel: string;
+}
+
 export interface UserMenuProps {
   onSignOutClick?: () => void;
   onThemeChange?: ThemeEvent;
@@ -13,6 +21,7 @@ export interface UserMenuProps {
   hideThemeSwitch?: boolean;
   menuContent?: JSX.Element;
   webcomponent: BaseProps['webcomponent'];
+  labels: Labels;
 }
 
 export interface HeaderProps extends BaseProps {

--- a/packages/components/components/elvis-header/src/react/mobileMenu/appSelector.tsx
+++ b/packages/components/components/elvis-header/src/react/mobileMenu/appSelector.tsx
@@ -3,14 +3,16 @@ import arrowRightFilled from '@elvia/elvis-assets-icons/dist/icons/arrowRightCir
 import { IconWrapper } from '@elvia/elvis-toolbox';
 import React, { useState } from 'react';
 
+import { Labels } from '../elviaHeader.types';
 import { AppSelectorTrigger, TextMicro, TextSmallStrong } from './mobileMenuStyles';
 
 interface Props {
+  labels: Labels;
   appTitle?: string;
   onClick: () => void;
 }
 
-export const AppSelector: React.FC<Props> = ({ appTitle, onClick }) => {
+export const AppSelector: React.FC<Props> = ({ labels, appTitle, onClick }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
@@ -20,7 +22,7 @@ export const AppSelector: React.FC<Props> = ({ appTitle, onClick }) => {
       onMouseLeave={() => setIsHovered(false)}
     >
       <div>
-        <TextSmallStrong>Velg applikasjon</TextSmallStrong>
+        <TextSmallStrong>{labels.selectAppLabel}</TextSmallStrong>
         <TextMicro>{appTitle}</TextMicro>
       </div>
       <IconWrapper icon={isHovered ? arrowRightFilled : arrowRight} size="sm" />

--- a/packages/components/components/elvis-header/src/react/mobileMenu/mobileMenu.tsx
+++ b/packages/components/components/elvis-header/src/react/mobileMenu/mobileMenu.tsx
@@ -44,6 +44,7 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
   menuContent,
   webcomponent,
   labels,
+  lang,
 }) => {
   const [view, setView] = useState<'mainPage' | 'appSelector'>('mainPage');
   const [backButtonIsHovered, setBackButtonIsHovered] = useState(false);
@@ -102,7 +103,7 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
                   <TextSmall>{email}</TextSmall>
                   <MobileMenuSlot ref={menuContentRef}>{menuContent}</MobileMenuSlot>
                   <AppSelector labels={labels} appTitle={appTitle} onClick={() => setView('appSelector')} />
-                  {!hideThemeSwitch && <ThemePicker onThemeChange={onThemeChange} />}
+                  {!hideThemeSwitch && <ThemePicker lang={lang} onThemeChange={onThemeChange} />}
                   <MobileMenuFooter>
                     <TertiaryButton size="sm" onClick={onSignOutClick}>
                       <IconWrapper icon={logout} size="xs" />

--- a/packages/components/components/elvis-header/src/react/mobileMenu/mobileMenu.tsx
+++ b/packages/components/components/elvis-header/src/react/mobileMenu/mobileMenu.tsx
@@ -43,6 +43,7 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
   onThemeChange,
   menuContent,
   webcomponent,
+  labels,
 }) => {
   const [view, setView] = useState<'mainPage' | 'appSelector'>('mainPage');
   const [backButtonIsHovered, setBackButtonIsHovered] = useState(false);
@@ -70,7 +71,7 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
     <>
       <IconButton
         onClick={() => onMobileMenuToggle(!userMenuIsOpen)}
-        aria-label="Åpne brukermeny"
+        aria-label={labels.openMenuLabel}
         aria-expanded={userMenuIsOpen}
         aria-haspopup="dialog"
         aria-controls="ewc-header-mobile-menu"
@@ -100,12 +101,12 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
                   <TextSmallStrong>{username}</TextSmallStrong>
                   <TextSmall>{email}</TextSmall>
                   <MobileMenuSlot ref={menuContentRef}>{menuContent}</MobileMenuSlot>
-                  <AppSelector appTitle={appTitle} onClick={() => setView('appSelector')} />
+                  <AppSelector labels={labels} appTitle={appTitle} onClick={() => setView('appSelector')} />
                   {!hideThemeSwitch && <ThemePicker onThemeChange={onThemeChange} />}
                   <MobileMenuFooter>
                     <TertiaryButton size="sm" onClick={onSignOutClick}>
                       <IconWrapper icon={logout} size="xs" />
-                      Logg ut
+                      {labels.logoutLabel}
                     </TertiaryButton>
                   </MobileMenuFooter>
                 </>
@@ -122,7 +123,7 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
                       icon={backButtonIsHovered ? arrowLeftCircleFilledColor : arrowLeftCircleColor}
                       size="sm"
                     />
-                    <TextMdStrong>Velg applikasjon</TextMdStrong>
+                    <TextMdStrong>{labels.selectAppLabel}</TextMdStrong>
                     <ButtonSpacer />
                   </BackButton>
                   <AppListContainer>

--- a/packages/components/components/elvis-header/src/react/mobileMenu/mobileMenu.tsx
+++ b/packages/components/components/elvis-header/src/react/mobileMenu/mobileMenu.tsx
@@ -44,7 +44,6 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
   menuContent,
   webcomponent,
   labels,
-  lang,
 }) => {
   const [view, setView] = useState<'mainPage' | 'appSelector'>('mainPage');
   const [backButtonIsHovered, setBackButtonIsHovered] = useState(false);
@@ -103,7 +102,7 @@ export const MobileMenu: React.FC<MobileUserMenuProps> = ({
                   <TextSmall>{email}</TextSmall>
                   <MobileMenuSlot ref={menuContentRef}>{menuContent}</MobileMenuSlot>
                   <AppSelector labels={labels} appTitle={appTitle} onClick={() => setView('appSelector')} />
-                  {!hideThemeSwitch && <ThemePicker lang={lang} onThemeChange={onThemeChange} />}
+                  {!hideThemeSwitch && <ThemePicker onThemeChange={onThemeChange} />}
                   <MobileMenuFooter>
                     <TertiaryButton size="sm" onClick={onSignOutClick}>
                       <IconWrapper icon={logout} size="xs" />

--- a/packages/components/components/elvis-header/src/react/sideNav/sideNav.tsx
+++ b/packages/components/components/elvis-header/src/react/sideNav/sideNav.tsx
@@ -3,16 +3,18 @@ import openMenu from '@elvia/elvis-assets-icons/dist/icons/openMenu';
 import { IconWrapper, useBreakpoint } from '@elvia/elvis-toolbox';
 import React from 'react';
 
+import { Labels } from '../elviaHeader.types';
 import { IconContainer, SideNavContainer, ToggleWidthButton } from './sideNavStyles';
 
 interface SideNavProps {
+  labels: Labels;
   isExpanded: boolean;
   onSideNavToggle: () => void;
   children: React.ReactNode;
 }
 
 export const SideNav = React.forwardRef<HTMLElement, SideNavProps>(
-  ({ children, isExpanded, onSideNavToggle }, ref) => {
+  ({ labels, children, isExpanded, onSideNavToggle }, ref) => {
     const isGtMobile = useBreakpoint('gt-mobile');
 
     return (
@@ -23,7 +25,7 @@ export const SideNav = React.forwardRef<HTMLElement, SideNavProps>(
             <IconContainer>
               <IconWrapper icon={isExpanded ? closeMenu : openMenu} size="sm" />
             </IconContainer>
-            {isExpanded ? 'Minimer' : 'Maksimer'}
+            {isExpanded ? labels.minimizeLabel : labels.maximizeLabel}
           </ToggleWidthButton>
         )}
       </SideNavContainer>

--- a/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
+++ b/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
@@ -1,4 +1,4 @@
-import { LanguageCode } from '@elvia/elvis-toolbox';
+import { useLanguage } from '@elvia/elvis-toolbox';
 import React, { useEffect, useState } from 'react';
 
 import { Theme, ThemeEvent, themeLocalStorageKey } from '../elviaHeader.types';
@@ -21,10 +21,11 @@ interface PickerTheme {
 
 interface ThemePickerProps {
   onThemeChange: ThemeEvent | undefined;
-  lang: LanguageCode;
 }
 
-export const ThemePicker: React.FC<ThemePickerProps> = ({ lang, onThemeChange }) => {
+export const ThemePicker: React.FC<ThemePickerProps> = ({ onThemeChange }) => {
+  const lang = useLanguage();
+
   const themes: PickerTheme[] = [
     { theme: 'light', label: lang === 'no' ? 'Lys' : 'Light' },
     { theme: 'dark', label: lang === 'no' ? 'Mørk' : 'Dark' },

--- a/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
+++ b/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
@@ -26,6 +26,8 @@ interface ThemePickerProps {
 export const ThemePicker: React.FC<ThemePickerProps> = ({ onThemeChange }) => {
   const lang = useLanguage();
 
+  const themeLabel = lang === 'no' ? 'Tema' : 'Theme';
+
   const themes: PickerTheme[] = [
     { theme: 'light', label: lang === 'no' ? 'Lys' : 'Light' },
     { theme: 'dark', label: lang === 'no' ? 'Mørk' : 'Dark' },
@@ -58,7 +60,7 @@ export const ThemePicker: React.FC<ThemePickerProps> = ({ onThemeChange }) => {
 
   return (
     <ThemeContainer>
-      <ThemeLabel>Tema</ThemeLabel>
+      <ThemeLabel>{themeLabel}</ThemeLabel>
       <ThemeListContainer>
         {themes.map((pickerTheme) => (
           <ThemeButton

--- a/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
+++ b/packages/components/components/elvis-header/src/react/themePicker/themePicker.tsx
@@ -1,3 +1,4 @@
+import { LanguageCode } from '@elvia/elvis-toolbox';
 import React, { useEffect, useState } from 'react';
 
 import { Theme, ThemeEvent, themeLocalStorageKey } from '../elviaHeader.types';
@@ -20,13 +21,14 @@ interface PickerTheme {
 
 interface ThemePickerProps {
   onThemeChange: ThemeEvent | undefined;
+  lang: LanguageCode;
 }
 
-export const ThemePicker: React.FC<ThemePickerProps> = ({ onThemeChange }) => {
+export const ThemePicker: React.FC<ThemePickerProps> = ({ lang, onThemeChange }) => {
   const themes: PickerTheme[] = [
-    { theme: 'light', label: 'Lys' },
-    { theme: 'dark', label: 'Mørk' },
-    { theme: 'system', label: 'System' },
+    { theme: 'light', label: lang === 'no' ? 'Lys' : 'Light' },
+    { theme: 'dark', label: lang === 'no' ? 'Mørk' : 'Dark' },
+    { theme: 'system', label: lang === 'no' ? 'System' : 'System' },
   ];
   const [currentTheme, setCurrentTheme] = useState<Theme>(getStoredActiveTheme());
 


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
Added automatic support for switching aria-labels based on the global lang attribute on the html-element on desktop and mobile menus, and themepicker under header component.