### PR TITLE
Lego 3669 header legge til voltagedashboard i app drawer

### DIFF
--- a/packages/components/components/elvis-header/CHANGELOG.json
+++ b/packages/components/components/elvis-header/CHANGELOG.json
@@ -3,6 +3,16 @@
   "name": "elvis-header",
   "content": [
     {
+      "date": "14.10.24",
+      "version": "1.13.0",
+      "changelog": [
+        {
+          "type": "new_feature",
+          "changes": ["Added Voltage Dashboard (Vd) to the app drawer."]
+        }
+      ]
+    },
+    {
       "date": "17.09.24",
       "version": "1.12.1",
       "changelog": [
@@ -18,7 +28,7 @@
       "changelog": [
         {
           "type": "new_feature",
-          "changes": ["Added ProjectPortal (PP) to the app drawer."]
+          "changes": ["Added ProjectPortal (Pp) to the app drawer."]
         },
         {
           "type": "patch",

--- a/packages/components/components/elvis-header/package.json
+++ b/packages/components/components/elvis-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-header",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/header",
   "repository": {

--- a/packages/components/components/elvis-header/src/react/elviaApps.ts
+++ b/packages/components/components/elvis-header/src/react/elviaApps.ts
@@ -110,6 +110,12 @@ export const appList = [
     url: 'sluttbrukeravbrudd',
     rotation: -67.5,
   },
+  {
+    name: 'Voltage Dashboard',
+    iconLetters: 'Vd',
+    url: 'voltagedashboard',
+    rotation: 168.75,
+  },
 ] as const satisfies AppLinks;
 
 const getUrlParts = (): string[] => {


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
This PR adds Voltage Dashboard (Vd)  to the App Drawer in the Header.
