### PR TITLE
LEGO-3672 checkbox small checkbox overflower ettersom teksten er større enn lineheighten

### DIFF
--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -3,6 +3,19 @@
   "name": "elvis",
   "content": [
     {
+      "version": "20.2.3",
+      "date": "November 4, 2024",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed a bug where the small checkbox would unnecessarily overflow when used in a container with the same height."
+          ],
+          "components": [{ "displayName": "Checkbox", "url": "https://design.elvia.io/components/checkbox" }]
+        }
+      ]
+    },
+    {
       "version": "20.2.2",
       "date": "September 24, 2024",
       "changelog": [

--- a/packages/elvis/package.json
+++ b/packages/elvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis",
-  "version": "20.2.2",
+  "version": "20.2.3",
   "description": "Elvia design system",
   "license": "GPL-3.0-only",
   "homepage": "https://design.elvia.io/components/css-library",

--- a/packages/elvis/percy/components/checkbox.html
+++ b/packages/elvis/percy/components/checkbox.html
@@ -132,5 +132,18 @@
         </label>
       </div>
     </form>
+    <div class="e-title-xs e-my-16">Long labels</div>
+    <form style="max-width: 20ch">
+      <label class="e-checkbox">
+        <input type="checkbox" />
+        <span class="e-checkbox__mark"></span>
+        <span class="e-checkbox__label">Lorem ipsum dolor sit amet consectetur adipisicing elit.</span>
+      </label>
+      <label class="e-checkbox e-checkbox--small">
+        <input type="checkbox" />
+        <span class="e-checkbox__mark"></span>
+        <span class="e-checkbox__label">Lorem ipsum dolor sit amet consectetur adipisicing elit.</span>
+      </label>
+    </form>
   </body>
 </html>

--- a/packages/elvis/src/components/form/checkbox.scss
+++ b/packages/elvis/src/components/form/checkbox.scss
@@ -120,8 +120,8 @@ $checkbox-mark-border-checked: 1px solid var(--e-checkbox-border-checked-color);
 
     .e-checkbox__label {
       @include mixins.typography('text-sm');
-
       line-height: 16px;
+      overflow-y: hidden;
     }
 
     // States - small specific


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
This PR hides the overflow-y of text inside the checkbox's label, which is often a few pixels taller than the actual line height.

It was tested in MDMx with `yalc`.

![Skjermbilde 2024-11-04 kl  11 26 38](https://github.com/user-attachments/assets/e938baed-509c-46f9-8d53-f8990a136dba)

https://github.com/user-attachments/assets/4d02529c-6b6f-411e-875e-c5ceca7636fd

