### PR TITLE
LEGO-3673 date picker range viser mix max feilmeldinger dobbelt

### DIFF
--- a/packages/components/components/elvis-datepicker-range/CHANGELOG.json
+++ b/packages/components/components/elvis-datepicker-range/CHANGELOG.json
@@ -3,6 +3,16 @@
   "name": "elvis-datepicker-range",
   "content": [
     {
+      "date": "11.11.24",
+      "version": "5.1.1",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": ["Updated internal dependencies."]
+        }
+      ]
+    },
+    {
       "date": "17.10.24",
       "version": "5.1.0",
       "changelog": [

--- a/packages/components/components/elvis-datepicker-range/package.json
+++ b/packages/components/components/elvis-datepicker-range/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-datepicker-range",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/datepicker-range",
   "repository": {
@@ -18,7 +18,7 @@
   "dependencies": {
     "@elvia/elvis-assets-icons": "^3.11.1",
     "@elvia/elvis-component-wrapper": "^4.2.0",
-    "@elvia/elvis-datepicker": "^9.1.0",
+    "@elvia/elvis-datepicker": "^9.1.1",
     "@elvia/elvis-timepicker": "^5.2.0",
     "@elvia/elvis-toolbox": "^12.1.0",
     "@emotion/react": "^11.11.4",

--- a/packages/components/components/elvis-datepicker/CHANGELOG.json
+++ b/packages/components/components/elvis-datepicker/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-datepicker",
   "content": [
     {
+      "date": "11.11.24",
+      "version": "9.1.1",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed a bug where the date was duplicated in the error messages for <code>minDate</code> and <code>maxDate</code>."
+          ]
+        }
+      ]
+    },
+    {
       "date": "17.10.24",
       "version": "9.1.0",
       "changelog": [

--- a/packages/components/components/elvis-datepicker/package.json
+++ b/packages/components/components/elvis-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-datepicker",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/datepicker",
   "repository": {

--- a/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.spec.tsx
+++ b/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.spec.tsx
@@ -36,3 +36,9 @@ test('should have year view open', async ({ mount, page }) => {
   await page.getByTestId('year-view-toggle').click();
   await percySnapshot(page, 'Datepicker: open year view');
 });
+
+test('should look correct when invalid', async ({ mount, page }) => {
+  await mount(<Datepicker value={new Date(2024, 0, 2)} maxDate={new Date(2024, 0, 1)} />);
+  test.setTimeout(300);
+  await percySnapshot(page, 'Datepicker: invalid');
+});

--- a/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.spec.tsx
+++ b/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.spec.tsx
@@ -36,9 +36,3 @@ test('should have year view open', async ({ mount, page }) => {
   await page.getByTestId('year-view-toggle').click();
   await percySnapshot(page, 'Datepicker: open year view');
 });
-
-test('should look correct when invalid', async ({ mount, page }) => {
-  await mount(<Datepicker value={new Date(2024, 0, 2)} maxDate={new Date(2024, 0, 1)} />);
-  test.setTimeout(300);
-  await percySnapshot(page, 'Datepicker: invalid');
-});

--- a/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.test.tsx
+++ b/packages/components/components/elvis-datepicker/src/react/elvia-datepicker.test.tsx
@@ -10,12 +10,12 @@ import { Datepicker } from './elvia-datepicker';
 describe('Elvis Datepicker', () => {
   describe('Default', () => {
     beforeEach(() => {
-      render(<Datepicker></Datepicker>);
+      render(<Datepicker />);
     });
 
     it('should have default label = Velg dato', () => {
       const datepickerLabel = screen.getByTestId('label');
-      expect(datepickerLabel).toHaveTextContent('Velg dato');
+      expect(datepickerLabel).toHaveTextContent(/^Velg dato$/);
     });
 
     it('should not have date selected when untouched', () => {
@@ -33,7 +33,7 @@ describe('Elvis Datepicker', () => {
   describe('Value = custom', () => {
     beforeEach(() => {
       const oddDateFilter = (d: Date) => d.getDate() % 2 !== 0;
-      render(<Datepicker value={new Date('2024/04/02')} disableDate={oddDateFilter}></Datepicker>);
+      render(<Datepicker value={new Date('2024/04/02')} disableDate={oddDateFilter} />);
     });
 
     it('should have value = 02.04.2024', () => {
@@ -46,7 +46,7 @@ describe('Elvis Datepicker', () => {
       await user.click(screen.getByTestId('popover-toggle'));
       await waitFor(() => expect(screen.queryByTestId('month-name')).toBeInTheDocument());
 
-      expect(screen.getByTestId('month-name')).toHaveTextContent('april 2024');
+      expect(screen.getByTestId('month-name')).toHaveTextContent(/^april 2024$/);
     });
 
     it('should be able to view next month', async () => {
@@ -56,7 +56,7 @@ describe('Elvis Datepicker', () => {
       await waitFor(() => expect(screen.queryByTestId('month-name')).toBeInTheDocument());
       await user.click(screen.getByTestId('next-month-btn'));
 
-      expect(screen.getByTestId('month-name')).toHaveTextContent('mai 2024');
+      expect(screen.getByTestId('month-name')).toHaveTextContent(/^mai 2024$/);
     });
 
     it('should be able to select month from the calendar', async () => {
@@ -87,23 +87,23 @@ describe('Elvis Datepicker', () => {
       await user.click(screen.getByTestId('year-view-toggle'));
       await user.click(screen.getByText('2025'));
 
-      expect(screen.queryByTestId('month-name')).toHaveTextContent('april 2025');
+      expect(screen.queryByTestId('month-name')).toHaveTextContent(/^april 2025$/);
     });
   });
 
   describe('Label = Custom label', () => {
     beforeEach(() => {
-      render(<Datepicker label="Custom label"></Datepicker>);
+      render(<Datepicker label="Custom label" />);
     });
 
     it('should have label = Custom label', () => {
-      expect(screen.getByTestId('label')).toHaveTextContent('Custom label');
+      expect(screen.getByTestId('label')).toHaveTextContent(/^Custom label$/);
     });
   });
 
   describe('Full width', () => {
     beforeEach(() => {
-      render(<Datepicker isFullWidth></Datepicker>);
+      render(<Datepicker isFullWidth />);
     });
 
     it('should have full width class', () => {
@@ -114,7 +114,7 @@ describe('Elvis Datepicker', () => {
 
   describe('Disabled', () => {
     beforeEach(() => {
-      render(<Datepicker isDisabled></Datepicker>);
+      render(<Datepicker isDisabled />);
     });
 
     it('should have a disabled input', () => {
@@ -128,7 +128,7 @@ describe('Elvis Datepicker', () => {
 
   describe('Required', () => {
     beforeEach(() => {
-      render(<Datepicker isRequired></Datepicker>);
+      render(<Datepicker isRequired />);
     });
 
     it('should not have error when untouched', () => {
@@ -144,13 +144,13 @@ describe('Elvis Datepicker', () => {
       await user.tab();
       await user.tab();
 
-      expect(screen.getByTestId('error')).toHaveTextContent('Velg dato');
+      expect(screen.getByTestId('error')).toHaveTextContent(/^Velg dato$/);
     });
   });
 
   describe('Custom error = Feil', () => {
     beforeEach(() => {
-      render(<Datepicker errorOptions={{ text: 'Feil' }}></Datepicker>);
+      render(<Datepicker errorOptions={{ text: 'Feil' }} />);
     });
 
     it('should have error style', () => {
@@ -159,14 +159,14 @@ describe('Elvis Datepicker', () => {
     });
 
     it('should have custom error in DOM', () => {
-      expect(screen.getByTestId('error')).toHaveTextContent('Feil');
+      expect(screen.getByTestId('error')).toHaveTextContent(/^Feil$/);
     });
   });
 
   describe('Min date', () => {
     beforeEach(() => {
       // A high min date, to ensure that the test doesn't break for a long time
-      render(<Datepicker minDate={new Date('2077/05/01')}></Datepicker>);
+      render(<Datepicker minDate={new Date('2077/05/01')} />);
     });
 
     it('should pick minimum date when opened', async () => {
@@ -179,7 +179,7 @@ describe('Elvis Datepicker', () => {
       const user = userEvent.setup();
       await user.click(screen.getByTestId('popover-toggle'));
       await waitFor(() => expect(screen.queryByTestId('month-name')).toBeInTheDocument());
-      expect(screen.getByTestId('month-name')).toHaveTextContent('mai 2077');
+      expect(screen.getByTestId('month-name')).toHaveTextContent(/^mai 2077$/);
     });
 
     it('should show an error if a date before the min date is typed into the input', async () => {
@@ -189,13 +189,13 @@ describe('Elvis Datepicker', () => {
       await user.tab();
       await user.tab();
 
-      expect(screen.queryByTestId('error')).toHaveTextContent('Tidligste dato er 01.05.2077');
+      expect(screen.queryByTestId('error')).toHaveTextContent(/^Tidligste dato er 01.05.2077$/);
     });
   });
 
   describe('Max date', () => {
     beforeEach(() => {
-      render(<Datepicker maxDate={new Date('2022/05/01')}></Datepicker>);
+      render(<Datepicker maxDate={new Date('2022/05/01')} />);
     });
 
     it('should pick maximum date when opened', async () => {
@@ -212,13 +212,13 @@ describe('Elvis Datepicker', () => {
       await user.tab();
       await user.tab();
 
-      expect(screen.queryByTestId('error')).toHaveTextContent('Seneste dato er 01.05.2022');
+      expect(screen.queryByTestId('error')).toHaveTextContent(/^Seneste dato er 01.05.2022$/);
     });
   });
 
   describe('className and inlineStyle passed to wrapper', () => {
     beforeEach(() => {
-      render(<Datepicker className="test-class" inlineStyle={{ margin: '24px' }}></Datepicker>);
+      render(<Datepicker className="test-class" inlineStyle={{ margin: '24px' }} />);
     });
 
     it('should have className', () => {
@@ -234,7 +234,7 @@ describe('Elvis Datepicker', () => {
 
   describe('Error state from prop', () => {
     beforeEach(() => {
-      render(<Datepicker errorOptions={{ isErrorState: true }}></Datepicker>);
+      render(<Datepicker errorOptions={{ isErrorState: true }} />);
     });
 
     it('should have error state', () => {
@@ -347,7 +347,7 @@ describe('Elvis Datepicker', () => {
       render(
         <div data-testid="dateppickers-wrapper">
           <Datepicker />
-          <Datepicker value={new Date('2024/04/02')}></Datepicker>
+          <Datepicker value={new Date('2024/04/02')} />
         </div>,
       );
 

--- a/packages/components/components/elvis-datepicker/src/react/getErrorText.ts
+++ b/packages/components/components/elvis-datepicker/src/react/getErrorText.ts
@@ -13,16 +13,16 @@ export const getErrorText = (
   const labels =
     lang === 'no'
       ? {
+          afterMaxDate: `Seneste dato er`,
+          beforeMinDate: `Tidligste dato er`,
           invalidDate: 'Ugyldig dato',
           required: 'Velg dato',
-          beforeMinDate: `Tidligste dato er ${getFormattedDate(lang, minDate, withTime)}`,
-          afterMaxDate: `Seneste dato er ${getFormattedDate(lang, maxDate, withTime)}`,
         }
       : {
+          afterMaxDate: `Latest date is`,
+          beforeMinDate: `Earliest date is`,
           invalidDate: 'Invalid date',
           required: 'Select date',
-          beforeMinDate: `Earliest date is ${getFormattedDate(lang, minDate, withTime)}`,
-          afterMaxDate: `Latest date is ${getFormattedDate(lang, maxDate, withTime)}`,
         };
 
   switch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3698,7 +3698,7 @@ __metadata:
   dependencies:
     "@elvia/elvis-assets-icons": "npm:^3.11.1"
     "@elvia/elvis-component-wrapper": "npm:^4.2.0"
-    "@elvia/elvis-datepicker": "npm:^9.1.0"
+    "@elvia/elvis-datepicker": "npm:^9.1.1"
     "@elvia/elvis-timepicker": "npm:^5.2.0"
     "@elvia/elvis-toolbox": "npm:^12.1.0"
     "@emotion/react": "npm:^11.11.4"
@@ -3717,7 +3717,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elvia/elvis-datepicker@npm:*, @elvia/elvis-datepicker@npm:^9.1.0, @elvia/elvis-datepicker@workspace:*, @elvia/elvis-datepicker@workspace:packages/components/components/elvis-datepicker":
+"@elvia/elvis-datepicker@npm:*, @elvia/elvis-datepicker@npm:^9.1.1, @elvia/elvis-datepicker@workspace:*, @elvia/elvis-datepicker@workspace:packages/components/components/elvis-datepicker":
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-datepicker@workspace:packages/components/components/elvis-datepicker"
   dependencies:


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
The date picker printed the min/max date twice in its "breforeMinDate" and "afterMaxDate" error messages.