### PR TITLE
LEGO-3684 Alert: punktliste inni alert blir fjernet ved bruk av css reset

### DIFF
--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -3,6 +3,19 @@
   "name": "elvis",
   "content": [
     {
+      "version": "20.2.4",
+      "date": "January 23, 2025",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Set <code>list-style: initial</code> for unordered lists in Alert component to preserve default bullets after CSS reset"
+          ],
+          "components": [{ "displayName": "Alert", "url": "https://design.elvia.io/components/alert" }]
+        }
+      ]
+    },
+    {
       "version": "20.2.3",
       "date": "November 4, 2024",
       "changelog": [

--- a/packages/elvis/package.json
+++ b/packages/elvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis",
-  "version": "20.2.3",
+  "version": "20.2.4",
   "description": "Elvia design system",
   "license": "GPL-3.0-only",
   "homepage": "https://design.elvia.io/components/css-library",

--- a/packages/elvis/src/components/alert.scss
+++ b/packages/elvis/src/components/alert.scss
@@ -77,6 +77,7 @@
   ul {
     padding: 0 0 0 17px;
     margin: 8px 0 0;
+    list-style: initial;
   }
 
   @include breakpoints.breakpoint-up(Mobile) {


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
In this PR, I restored the default list bullets in the Alert component by setting `list-style: initial`. The bullets weren't showing up because our CSS reset was setting `list-style: none`.