### PR TITLE
LEGO-3507 spacing fjerne spacing variabler fra elvis

### DIFF
--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -9,10 +9,14 @@
       "changelog": [
         {
           "type": "breaking_changes",
-          "changes": ["Removed the class <code>.e-table-footnote</code>."],
+          "changes": [
+            "Removed the class <code>.e-table-footnote</code>.",
+            "Removed all CSS custom properties for spacing (e.g. <code>--e-spacing-8</code>, <code>--e-spacing-16</code>, etc.). Use pixel values directly instead."
+          ],
           "components": [{ "displayName": "Table", "url": "https://design.elvia.io/components/table" }],
           "fixes": [
-            "Replace all instances of <code>.e-table-footnote</code> with <code>.e-table__footnote</code>."
+            "Replace all instances of <code>.e-table-footnote</code> with <code>.e-table__footnote</code>.",
+            "Replace all spacing custom properties with their direct pixel values (e.g. <code>--e-spacing-8</code> becomes <code>8px</code>)"
           ]
         },
         {

--- a/packages/elvis/src/utilities/spacing.scss
+++ b/packages/elvis/src/utilities/spacing.scss
@@ -136,9 +136,5 @@ $spacing: (
         margin-bottom: -$value !important;
       }
     }
-    // Making CSS variables for spacing-variables
-    :root {
-      --e-spacing-#{$label}: #{$value};
-    }
   }
 }


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

Task: https://elvia.atlassian.net/browse/LEGO-3507

- [ ] Bumpet package?
- [x] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
In this PR I have removed the spacing CSS custom properties. The version will be bumped in another PR. See https://elvia.atlassian.net/browse/LEGO-3692
