### PR TITLE
LEGO-3694 alert action burde ha flex wrap

### DIFF
--- a/packages/elvis/CHANGELOG.json
+++ b/packages/elvis/CHANGELOG.json
@@ -23,9 +23,13 @@
           "type": "bug_fix",
           "changes": [
             "Fixed a bug where input fields within a table with the <code>.e-input---invalid</code> class did not display the correct border color.",
-            "Fixed a bug where input fields within a table with the <code>.e-input---readonly</code> class did get the correct styles."
+            "Fixed a bug where input fields within a table with the <code>.e-input---readonly</code> class did get the correct styles.",
+            "Fixed a bug where buttons and links inside the the <code>.e-alert__actions</code> class would not wrap and, therefore, cause overflow on narrow screens."
           ],
-          "components": [{ "displayName": "Table", "url": "https://design.elvia.io/components/table" }]
+          "components": [
+            { "displayName": "Table", "url": "https://design.elvia.io/components/table" },
+            { "displayName": "Alert", "url": "https://design.elvia.io/components/alert" }
+          ]
         },
         {
           "type": "patch",

--- a/packages/elvis/percy/components/local-alert.html
+++ b/packages/elvis/percy/components/local-alert.html
@@ -8,9 +8,9 @@
   </head>
   <body class="e-color-background-1">
     <div class="e-title-xs e-my-16">Local Alert</div>
-    <div class="e-mt-16 e-flex e-flex-direction-column e-gap-72">
-      <div>
-        <h5>Regular</h5>
+    <div class="e-mt-16 e-flex e-flex-direction-column e-gap-32">
+      <div class="e-flex e-flex-direction-column e-gap-8">
+        <h5 class="e-m-0">Regular</h5>
         <div class="e-alert e-alert--local">
           <div class="e-alert__icon">
             <i class="e-icon e-icon--remove_circle e-icon--color-red" aria-hidden="true"></i>
@@ -49,8 +49,8 @@
         </div>
       </div>
 
-      <div>
-        <h5>Without title</h5>
+      <div class="e-flex e-flex-direction-column e-gap-8">
+        <h5 class="e-m-0">Without title</h5>
         <div class="e-alert e-alert--local">
           <div class="e-alert__icon">
             <i class="e-icon e-icon--remove_circle e-icon--color-red" aria-hidden="true"></i>
@@ -86,8 +86,8 @@
         </div>
       </div>
 
-      <div>
-        <h5>Actions</h5>
+      <div class="e-flex e-flex-direction-column e-gap-8">
+        <h5 class="e-m-0">Actions</h5>
         <div class="e-alert e-alert--local">
           <div class="e-alert__icon">
             <i class="e-icon e-icon--remove_circle e-icon--color-red" aria-hidden="true"></i>
@@ -145,8 +145,8 @@
         </div>
       </div>
 
-      <div>
-        <h5>Links</h5>
+      <div class="e-flex e-flex-direction-column e-gap-8">
+        <h5 class="e-m-0">Links</h5>
         <div class="e-alert">
           <div class="e-alert__icon">
             <i class="e-icon e-icon--remove_circle e-icon--color-red" aria-hidden="true"></i>
@@ -219,8 +219,8 @@
         </div>
       </div>
 
-      <div>
-        <h5>Closable</h5>
+      <div class="e-flex e-flex-direction-column e-gap-8">
+        <h5 class="e-m-0">Closable</h5>
         <div class="e-alert">
           <div class="e-alert__icon">
             <i class="e-icon e-icon--remove_circle e-icon--color-danger" aria-hidden="true"></i>

--- a/packages/elvis/percy/components/local-alert.html
+++ b/packages/elvis/percy/components/local-alert.html
@@ -8,7 +8,7 @@
   </head>
   <body class="e-color-background-1">
     <div class="e-title-xs e-my-16">Local Alert</div>
-    <div class="e-mt-16" style="display: grid; grid-auto-rows: 600px">
+    <div class="e-mt-16 e-flex e-flex-direction-column e-gap-72">
       <div>
         <h5>Regular</h5>
         <div class="e-alert e-alert--local">
@@ -159,8 +159,8 @@
                 <a class="e-link e-link--inline">inline link.</a>
               </div>
               <div class="e-alert__links">
-                <a class="e-link" href="https://design.elvia.io">Link 1</a>
-                <a class="e-link" href="https://design.elvia.io">Link 2</a>
+                <a class="e-link" href="#">Link 1</a>
+                <a class="e-link" href="#">Link 2</a>
               </div>
             </div>
           </div>
@@ -176,8 +176,8 @@
               <a class="e-link e-link--inline">inline link.</a>
             </div>
             <div class="e-alert__actions">
-              <a class="e-link" href="https://design.elvia.io">Link 1</a>
-              <a class="e-link" href="https://design.elvia.io">Link 2</a>
+              <a class="e-link" href="#">Link 1</a>
+              <a class="e-link" href="#">Link 2</a>
             </div>
           </div>
         </div>
@@ -193,8 +193,26 @@
                 <a class="e-link e-link--inline">inline link.</a>
               </div>
               <div class="e-alert__links">
-                <a class="e-link" href="https://design.elvia.io">Link 1</a>
-                <a class="e-link" href="https://design.elvia.io">Link 2</a>
+                <a class="e-link" href="#">Link 1</a>
+                <a class="e-link" href="#">Link 2</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="e-alert e-alert--info e-alert--local e-alert--links">
+          <div class="e-alert__icon">
+            <i class="e-icon e-icon--check_circle" aria-hidden="true"></i>
+          </div>
+          <div class="e-alert__content">
+            <div class="e-alert__title">Kort tittel</div>
+            <div class="e-alert__text">
+              <div>
+                Description with a list and an
+                <a class="e-link e-link--inline">inline link.</a>
+              </div>
+              <div class="e-alert__links">
+                <a class="e-link" href="#">Lorem ipsum dolor sit, amet consectetur adipisicing elit.</a>
+                <a class="e-link" href="#">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</a>
               </div>
             </div>
           </div>

--- a/packages/elvis/percy/components/local-alert.html
+++ b/packages/elvis/percy/components/local-alert.html
@@ -143,6 +143,25 @@
             </div>
           </div>
         </div>
+        <div class="e-alert e-alert--info e-alert--local e-alert--actions">
+          <div class="e-alert__icon">
+            <i class="e-icon e-icon--check_circle" aria-hidden="true"></i>
+          </div>
+          <div class="e-alert__content">
+            <div class="e-alert__title">Kort tittel</div>
+            <div class="e-alert__text">
+              <div>Description with actions.</div>
+              <div class="e-alert__actions">
+                <button class="e-btn e-btn--secondary e-btn--sm">
+                  <span class="e-btn__title">Lorem ipsum dolor sit, amet.</span>
+                </button>
+                <button class="e-btn e-btn--sm">
+                  <span class="e-btn__title">Lorem ipsum dolor sit, amet.</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="e-flex e-flex-direction-column e-gap-8">

--- a/packages/elvis/src/components/alert.scss
+++ b/packages/elvis/src/components/alert.scss
@@ -67,6 +67,7 @@
     align-items: center;
     gap: 24px;
     margin-top: 16px;
+    flex-wrap: wrap;
   }
 
   .e-alert__close {

--- a/packages/web/src/app/doc-pages/components/alert-messages/alert-local-actions-ceg/alert-local-actions-ceg.component.html
+++ b/packages/web/src/app/doc-pages/components/alert-messages/alert-local-actions-ceg/alert-local-actions-ceg.component.html
@@ -1,0 +1,26 @@
+<div class="e-alert e-alert--info" role="note">
+  <div class="e-alert__icon">
+    <e-icon name="informationCircle" class="e-icon--color-grey"> </e-icon>
+  </div>
+  <div class="e-alert__title">Slå sammen anlegg eller be om tilgang</div>
+  <div class="e-alert__text">
+    <div>
+      Du kan slå sammen anlegget ditt med andre anlegg du har tilgang til på samme gårds-, bruks- eller
+      festenummer. Om du ikke finner anlegget du ser etter, kan du be om tilgang her:
+    </div>
+    <div class="e-alert__actions">
+      <a class="e-link e-link--new-tab" href="#">
+        <span class="e-link__title"> Privat kundeforhold </span>
+        <span class="e-link__icon">
+          <e-icon name="newTabBold"> </e-icon>
+        </span>
+      </a>
+      <a class="e-link e-link--new-tab" href="#">
+        <span class="e-link__title"> Bedriftskundeforhold </span>
+        <span class="e-link__icon">
+          <e-icon name="newTabBold"> </e-icon>
+        </span>
+      </a>
+    </div>
+  </div>
+</div>

--- a/packages/web/src/app/doc-pages/components/alert-messages/alert-local-actions-ceg/alert-local-actions-ceg.component.ts
+++ b/packages/web/src/app/doc-pages/components/alert-messages/alert-local-actions-ceg/alert-local-actions-ceg.component.ts
@@ -1,0 +1,14 @@
+import { CUSTOM_ELEMENTS_SCHEMA, Component } from '@angular/core';
+
+import * as template from './alert-local-actions-ceg.component.html';
+import { StaticComponentExample } from 'src/app/shared/component-documentation/ceg';
+
+@Component({
+  selector: 'app-alert-local-actions-ceg',
+  templateUrl: './alert-local-actions-ceg.component.html',
+  providers: [{ provide: StaticComponentExample, useExisting: AlertLocalActionsCegComponent }],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class AlertLocalActionsCegComponent implements StaticComponentExample {
+  html = template.default;
+}

--- a/packages/web/src/app/doc-pages/components/alert-messages/alert-messages.component.html
+++ b/packages/web/src/app/doc-pages/components/alert-messages/alert-messages.component.html
@@ -160,6 +160,16 @@
           <app-alert-local-closable-ceg />
         </app-static-ceg>
       </app-component-subsubsection>
+
+      <app-component-subsubsection [sectionTitle]="'Actions'">
+        Local alerts can also have actions, such as buttons or link. Use the
+        <code>.e-alert__actions</code>
+        class as a descendant of
+        <code>e-alert__text</code>
+        <app-static-ceg>
+          <app-alert-local-actions-ceg />
+        </app-static-ceg>
+      </app-component-subsubsection>
     </app-component-subsection>
   </app-component-section>
 

--- a/packages/web/src/app/doc-pages/components/alert-messages/alert-messages.component.ts
+++ b/packages/web/src/app/doc-pages/components/alert-messages/alert-messages.component.ts
@@ -11,6 +11,7 @@ import { AlertCegComponent } from './alert-ceg/alert-ceg.component';
 import { AlertGlobalActionsCegComponent } from './alert-global-actions-ceg/alert-global-actions-ceg.component';
 import { AlertGlobalCegComponent } from './alert-global-ceg/alert-global-ceg.component';
 import { AlertGlobalClosableCegComponent } from './alert-global-closable-ceg/alert-global-closable-ceg.component';
+import { AlertLocalActionsCegComponent } from './alert-local-actions-ceg/alert-local-actions-ceg.component';
 import { AlertLocalCegComponent } from './alert-local-ceg/alert-local-ceg.component';
 import { AlertLocalClosableCegComponent } from './alert-local-closable-ceg/alert-local-closable-ceg.component';
 import { AlertRoleAlertCegComponent } from './alert-role-alert-ceg/alert-role-alert-ceg.component';
@@ -38,6 +39,7 @@ import { AlertRoleStatusCegComponent } from './alert-role-status-ceg/alert-role-
     AlertRoleAlertCegComponent,
     AlertRoleStatusCegComponent,
     AlertRoleNoteCegComponent,
+    AlertLocalActionsCegComponent,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/packages/web/src/app/shared/component-documentation/component-structure/component-header/component-header.component.html
+++ b/packages/web/src/app/shared/component-documentation/component-structure/component-header/component-header.component.html
@@ -23,7 +23,7 @@
       }
     </div>
   </div>
-  <div class="description-container e-text-lead">
+  <div class="description-container e-text-lead e-text-wrap-balance">
     <ng-content select="headerDescription" />
   </div>
   <app-sub-menu *ifViewportSize="['sm', 'md']" class="e-mt-40 e-mb-16 full-width" />


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [x] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
In this PR I added `flex-wrap: wrap;` to the actions (`.e-alert__actions`) inside an Alert so that they wrap on a mobile screen.
I also added a documentation section that shows how to use actions, as it was not documented that they are a descendent of `.e-alert__text`. The Example comes from Min Side.
Lastly, I added a Percy test.
