### PR TITLE
LEGO 3689 date picker reset time mangler deafult verdi i api tabell

### DIFF
--- a/packages/web/src/app/doc-pages/components/component-data.interface.ts
+++ b/packages/web/src/app/doc-pages/components/component-data.interface.ts
@@ -6,7 +6,9 @@ type ChildlessType = PrimitiveType | EventType;
 type BaseType<T> = T extends (infer U)[] ? U : T;
 
 interface PropBase {
-  // Indicates whether a prop is required for the component.
+  /**
+   * Indicates whether a prop is required for the component.
+   */
   isRequired?: boolean;
 
   /**
@@ -18,6 +20,13 @@ interface PropBase {
    * '"left" | "center" | "right"'
    */
   type: string;
+  /**
+   * The default value the prop will have if not set by the user.
+   * @example
+   * 'true'
+   * 'dd.mm.åååå'
+   * 'green'
+   */
   default?: string | number | boolean;
   /** An example of how the prop can be used. Typed as a string, but should be a valid ts code example.
    * @example

--- a/packages/web/src/app/doc-pages/components/forms/datepicker-doc/datepicker-data.ts
+++ b/packages/web/src/app/doc-pages/components/forms/datepicker-doc/datepicker-data.ts
@@ -83,6 +83,7 @@ const datepickerData: ComponentData<Omit<DatepickerProps, 'dateRangeProps' | 'on
     resetTime: {
       type: 'boolean',
       description: 'Whether to reset the time value in the emitted Date object to 00:00:00.',
+      default: 'false',
     },
     placeholder: {
       type: 'string',


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [ ] Bumpet package?
- [ ] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
This PR adds a default value for the `resetTime`-prop for the datepicker.
