### PR TITLE
LEGO-3699 tooltip inline styles pa tooltip virker ikke

### DIFF
--- a/packages/components/components/elvis-tooltip/CHANGELOG.json
+++ b/packages/components/components/elvis-tooltip/CHANGELOG.json
@@ -3,6 +3,18 @@
   "$schema": "../../changelogSchema.json",
   "content": [
     {
+      "date": "03.04.25",
+      "version": "1.3.7",
+      "changelog": [
+        {
+          "type": "patch",
+          "changes": [
+            "The <code>inlineStyle</code> and <code>className</code> prop values are now passed to the tooltip popup instead of the slot content. Be aware that your <code>inlineStyle</code> can interfere with the <code>@floating-ui</code> positioning."
+          ]
+        }
+      ]
+    },
+    {
       "date": "30.05.24",
       "version": "1.3.6",
       "changelog": [

--- a/packages/components/components/elvis-tooltip/CHANGELOG.json
+++ b/packages/components/components/elvis-tooltip/CHANGELOG.json
@@ -9,7 +9,8 @@
         {
           "type": "patch",
           "changes": [
-            "The <code>inlineStyle</code> and <code>className</code> prop values are now passed to the tooltip popup instead of the slot content. Be aware that your <code>inlineStyle</code> can interfere with the <code>@floating-ui</code> positioning."
+            "The <code>inlineStyle</code> and <code>className</code> prop values are now passed to the tooltip popup instead of the slot content. Be aware that your <code>inlineStyle</code> can interfere with the <code>@floating-ui</code> positioning.",
+            "Updated internal dependencies."
           ]
         }
       ]

--- a/packages/components/components/elvis-tooltip/package.json
+++ b/packages/components/components/elvis-tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-tooltip",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/tooltip",
   "repository": {

--- a/packages/components/components/elvis-tooltip/package.json
+++ b/packages/components/components/elvis-tooltip/package.json
@@ -16,8 +16,8 @@
     "dist"
   ],
   "dependencies": {
-    "@elvia/elvis-component-wrapper": "^4.2.0",
-    "@elvia/elvis-toolbox": "^12.0.1",
+    "@elvia/elvis-component-wrapper": "^4.3.0",
+    "@elvia/elvis-toolbox": "^12.1.0",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@floating-ui/react": "~0.26.16"

--- a/packages/components/components/elvis-tooltip/src/react/elvia-tooltip.tsx
+++ b/packages/components/components/elvis-tooltip/src/react/elvia-tooltip.tsx
@@ -118,16 +118,15 @@ export const Tooltip: React.FC<TooltipProps> = ({
       {isOpen && !isDisabled && (
         <FloatingPortal>
           <TooltipPopup
-            position={placement as TooltipPosition}
-            ref={refs.setFloating}
-            style={floatingStyles}
+            aria-live="polite"
+            className={className ?? ''}
             fadeOut={fadeOut}
             onAnimationEnd={onAnimationEnd}
-            aria-live="polite"
+            position={placement as TooltipPosition}
+            ref={refs.setFloating}
+            style={{ ...floatingStyles, ...inlineStyle }}
           >
-            <TooltipContent className={className ?? ''} style={{ ...inlineStyle }} ref={overlayRef}>
-              {content}
-            </TooltipContent>
+            <TooltipContent ref={overlayRef}>{content}</TooltipContent>
           </TooltipPopup>
         </FloatingPortal>
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2719,8 +2719,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elvia/elvis-tooltip@workspace:packages/components/components/elvis-tooltip"
   dependencies:
-    "@elvia/elvis-component-wrapper": "npm:^4.2.0"
-    "@elvia/elvis-toolbox": "npm:^12.0.1"
+    "@elvia/elvis-component-wrapper": "npm:^4.3.0"
+    "@elvia/elvis-toolbox": "npm:^12.1.0"
     "@emotion/react": "npm:^11.11.4"
     "@emotion/styled": "npm:^11.11.5"
     "@floating-ui/react": "npm:~0.26.16"


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [ ] Correct date in changelog?

## Describe PR briefly:
In this PR I move the inlinestyles and classNames to the tooltip popover as the tooltip content uses display block and therefore is hard to adjust with CSS
