### PR TITLE
Potential fix for code scanning alert no. 245: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runComponentTests.yml
+++ b/.github/workflows/runComponentTests.yml
@@ -1,4 +1,6 @@
 name: Run Component Tests
+permissions:
+  contents: read
 on:
   pull_request:
     paths:

--- a/.github/workflows/runComponentTests.yml
+++ b/.github/workflows/runComponentTests.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'packages/components/components/**'
       - 'yarn.lock'
+      - '.github/workflows/**'
 jobs:
   runComponentTests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/3lvia/designsystem/security/code-scanning/245](https://github.com/3lvia/designsystem/security/code-scanning/245)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, it only needs to read the repository contents to check out the code and run tests. Therefore, we will set `contents: read` as the permission. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
