### PR TITLE
Potential fix for code scanning alert no. 243: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,6 +1,7 @@
 name: Percy CI
 permissions:
   contents: read
+  checks: write
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,4 +1,6 @@
 name: Percy CI
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/3lvia/designsystem/security/code-scanning/243](https://github.com/3lvia/designsystem/security/code-scanning/243)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's operations, it primarily needs to read repository contents (e.g., for checking out code and running tests). Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
