### PR TITLE
LEGO-3700 fix(tabs): set `aria-controls` to "ewc-tabpanel-"

### DIFF
--- a/packages/components/components/elvis-tabs/CHANGELOG.json
+++ b/packages/components/components/elvis-tabs/CHANGELOG.json
@@ -3,6 +3,18 @@
   "name": "elvis-tabs",
   "content": [
     {
+      "date": "14.05.25",
+      "version": "2.3.1",
+      "changelog": [
+        {
+          "type": "bug_fix",
+          "changes": [
+            "Fixed a bug where the tabs component would set the incorrect <code>aria-controls</code> on its tabs. It is now set to <code>ewc-tabpanel-[index]</code>."
+          ]
+        }
+      ]
+    },
+    {
       "date": "24.09.24",
       "version": "2.3.0",
       "changelog": [

--- a/packages/components/components/elvis-tabs/package.json
+++ b/packages/components/components/elvis-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elvia/elvis-tabs",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "homepage": "https://design.elvia.io/components/tabs",
   "repository": {

--- a/packages/components/components/elvis-tabs/src/react/elvia-tabs.test.tsx
+++ b/packages/components/components/elvis-tabs/src/react/elvia-tabs.test.tsx
@@ -53,6 +53,12 @@ describe('Elvis Tabs', () => {
       const tabLabel = screen.getByText('Oranges');
       expect(tabLabel).toHaveStyle('text-shadow: 0 0 0 black,0 0 0.5px black');
     });
+
+    it('should have aria-controls and id', () => {
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs[0].getAttribute('aria-controls')).toBe('ewc-tabpanel-0');
+      expect(tabs[0].getAttribute('id')).toBe('ewc-tabs-0');
+    });
   });
 
   describe('className and inlineStyle passed to wrapper', () => {

--- a/packages/components/components/elvis-tabs/src/react/elvia-tabs.test.tsx
+++ b/packages/components/components/elvis-tabs/src/react/elvia-tabs.test.tsx
@@ -130,6 +130,14 @@ describe('Elvis Tabs', () => {
         <div data-testid="tabs-wrapper">
           <Tabs items={items} tabIdPrefix={'test'} />
           <Tabs items={items} value={2} />
+
+          <div id="ewc-tabpanel-0" aria-labelledby="ewc-tabs-0"></div>
+          <div id="ewc-tabpanel-1" aria-labelledby="ewc-tabs-1"></div>
+          <div id="ewc-tabpanel-2" aria-labelledby="ewc-tabs-2"></div>
+
+          <div id="ewc-tabpanel-test-0" aria-labelledby="ewc-tabs-test-0"></div>
+          <div id="ewc-tabpanel-test-1" aria-labelledby="ewc-tabs-test-1"></div>
+          <div id="ewc-tabpanel-test-2" aria-labelledby="ewc-tabs-test-2"></div>
         </div>,
       );
 

--- a/packages/components/components/elvis-tabs/src/react/elvia-tabs.test.tsx
+++ b/packages/components/components/elvis-tabs/src/react/elvia-tabs.test.tsx
@@ -131,13 +131,13 @@ describe('Elvis Tabs', () => {
           <Tabs items={items} tabIdPrefix={'test'} />
           <Tabs items={items} value={2} />
 
-          <div id="ewc-tabpanel-0" aria-labelledby="ewc-tabs-0"></div>
-          <div id="ewc-tabpanel-1" aria-labelledby="ewc-tabs-1"></div>
-          <div id="ewc-tabpanel-2" aria-labelledby="ewc-tabs-2"></div>
+          <div id="ewc-tabpanel-0" aria-labelledby="ewc-tabs-0" role="tabpanel"></div>
+          <div id="ewc-tabpanel-1" aria-labelledby="ewc-tabs-1" role="tabpanel"></div>
+          <div id="ewc-tabpanel-2" aria-labelledby="ewc-tabs-2" role="tabpanel"></div>
 
-          <div id="ewc-tabpanel-test-0" aria-labelledby="ewc-tabs-test-0"></div>
-          <div id="ewc-tabpanel-test-1" aria-labelledby="ewc-tabs-test-1"></div>
-          <div id="ewc-tabpanel-test-2" aria-labelledby="ewc-tabs-test-2"></div>
+          <div id="ewc-tabpanel-test-0" aria-labelledby="ewc-tabs-test-0" role="tabpanel"></div>
+          <div id="ewc-tabpanel-test-1" aria-labelledby="ewc-tabs-test-1" role="tabpanel"></div>
+          <div id="ewc-tabpanel-test-2" aria-labelledby="ewc-tabs-test-2" role="tabpanel"></div>
         </div>,
       );
 

--- a/packages/components/components/elvis-tabs/src/react/elvia-tabs.tsx
+++ b/packages/components/components/elvis-tabs/src/react/elvia-tabs.tsx
@@ -30,6 +30,7 @@ export const Tabs: FC<TabsProps> = ({
 }) => {
   const [selectedIndex, setSelectedIndex] = useState(value);
   const uniqueId = `ewc-tabs-${tabIdPrefix ? tabIdPrefix + '-' : ''}`;
+  const tabpanelId = `ewc-tabpanel-${tabIdPrefix ? tabIdPrefix + '-' : ''}`;
   const { ref: scrollContainerRef } = useRovingFocus<HTMLDivElement>({
     dir: 'horizontal',
     observableAttributes: ['aria-hidden'],
@@ -104,7 +105,7 @@ export const Tabs: FC<TabsProps> = ({
         {items &&
           items.map((item, i) => (
             <Tab
-              aria-controls={uniqueId + i}
+              aria-controls={tabpanelId + i}
               aria-selected={selectedIndex === i}
               id={uniqueId + i}
               isInverted={isInverted ?? false}

--- a/packages/web/src/app/dev/v2-playground/v2-playground.component.html
+++ b/packages/web/src/app/dev/v2-playground/v2-playground.component.html
@@ -254,19 +254,13 @@
       <!--Datepicker-->
       <div class="example-wrapper">
         <h3>DatePicker</h3>
-        <elvia-datepicker
-          [value]="date"
-          resetTime
-          (valueOnChange)="writeDate($any($event).detail.value)"
-        />
+        <elvia-datepicker [value]="date" resetTime (valueOnChange)="writeDate($any($event).detail.value)" />
       </div>
 
       <!--Date range picker-->
       <div class="example-wrapper">
         <h3>Date range picker</h3>
-        <elvia-datepicker-range
-          (valueOnChangeISOString)="writeDate($any($event).detail.value)"
-        />
+        <elvia-datepicker-range (valueOnChangeISOString)="writeDate($any($event).detail.value)" />
         <elvia-datepicker-range
           hasTimepickers
           [minDate]="minDateRange"
@@ -509,31 +503,31 @@
         />
         @switch (selectedTabIndex) {
           @case (0) {
-            <div id="ewc-tabpanel-0" aria-labelledby="ewc-tabs-0">
+            <div role="tabpanel" id="ewc-tabpanel-0" aria-labelledby="ewc-tabs-0">
               <p>Apples are made of 25% air, which is why they float.</p>
               <button class="e-btn e-btn--sm">Buy 🍎</button>
             </div>
           }
           @case (1) {
-            <div id="ewc-tabpanel-1" aria-labelledby="ewc-tabs-1">
+            <div role="tabpanel" id="ewc-tabpanel-1" aria-labelledby="ewc-tabs-1">
               <p>Oranges were originally green when first cultivated.</p>
               <button class="e-btn e-btn--sm">Buy 🍊</button>
             </div>
           }
           @case (2) {
-            <div id="ewc-tabpanel-2" aria-labelledby="ewc-tabs-2">
+            <div role="tabpanel" id="ewc-tabpanel-2" aria-labelledby="ewc-tabs-2">
               <p>Bananas are berries, but strawberries are not.</p>
               <button class="e-btn e-btn--sm">Buy 🍌</button>
             </div>
           }
           @case (3) {
-            <div id="ewc-tabpanel-3" aria-labelledby="ewc-tabs-3">
+            <div role="tabpanel" id="ewc-tabpanel-3" aria-labelledby="ewc-tabs-3">
               <p>Grapes explode when you put them in the microwave.</p>
               <button class="e-btn e-btn--sm">Buy 🍇</button>
             </div>
           }
           @case (4) {
-            <div id="ewc-tabpanel-4" aria-labelledby="ewc-tabs-4">
+            <div role="tabpanel" id="ewc-tabpanel-4" aria-labelledby="ewc-tabs-4">
               <p>Kiwis were originally called <em>Chinese gooseberries</em>.</p>
               <button class="e-btn e-btn--sm">Buy 🥝</button>
             </div>
@@ -555,11 +549,7 @@
 
           <elvia-timepicker size="small" />
 
-          <elvia-timepicker
-            label="Only hours"
-            [value]="timepickerValue"
-            minuteInterval="60"
-          />
+          <elvia-timepicker label="Only hours" [value]="timepickerValue" minuteInterval="60" />
 
           <elvia-timepicker isDisabled="true" />
 
@@ -586,10 +576,7 @@
         <div class="e-flex e-flex-direction-row e-gap-16">
           <p class="e-text-md">
             This is a text to test out the new
-            <elvia-tooltip
-              content="This is a tooltip! The content is pretty long."
-              trigger="tooltip!"
-            />
+            <elvia-tooltip content="This is a tooltip! The content is pretty long." trigger="tooltip!" />
           </p>
 
           <elvia-tooltip

--- a/packages/web/src/app/dev/v2-playground/v2-playground.component.html
+++ b/packages/web/src/app/dev/v2-playground/v2-playground.component.html
@@ -502,7 +502,43 @@
       <!--Tabs-->
       <div class="example-wrapper">
         <h3>Tabs</h3>
-        <elvia-tabs [items]="['Epler', 'Appelsin', 'Bananer', 'Druer', 'Kiwi']" [value]="1" />
+        <elvia-tabs
+          [items]="['Epler', 'Appelsin', 'Bananer', 'Druer', 'Kiwi']"
+          [value]="selectedTabIndex"
+          (valueOnChange)="tabsValueOnChange($any($event).detail.value)"
+        />
+        @switch (selectedTabIndex) {
+          @case (0) {
+            <div id="ewc-tabpanel-0" aria-labelledby="ewc-tabs-0">
+              <p>Apples are made of 25% air, which is why they float.</p>
+              <button class="e-btn e-btn--sm">Buy 🍎</button>
+            </div>
+          }
+          @case (1) {
+            <div id="ewc-tabpanel-1" aria-labelledby="ewc-tabs-1">
+              <p>Oranges were originally green when first cultivated.</p>
+              <button class="e-btn e-btn--sm">Buy 🍊</button>
+            </div>
+          }
+          @case (2) {
+            <div id="ewc-tabpanel-2" aria-labelledby="ewc-tabs-2">
+              <p>Bananas are berries, but strawberries are not.</p>
+              <button class="e-btn e-btn--sm">Buy 🍌</button>
+            </div>
+          }
+          @case (3) {
+            <div id="ewc-tabpanel-3" aria-labelledby="ewc-tabs-3">
+              <p>Grapes explode when you put them in the microwave.</p>
+              <button class="e-btn e-btn--sm">Buy 🍇</button>
+            </div>
+          }
+          @case (4) {
+            <div id="ewc-tabpanel-4" aria-labelledby="ewc-tabs-4">
+              <p>Kiwis were originally called <em>Chinese gooseberries</em>.</p>
+              <button class="e-btn e-btn--sm">Buy 🥝</button>
+            </div>
+          }
+        }
       </div>
 
       <!--Timepicker-->

--- a/packages/web/src/app/dev/v2-playground/v2-playground.component.ts
+++ b/packages/web/src/app/dev/v2-playground/v2-playground.component.ts
@@ -264,6 +264,13 @@ export class v2PlaygroundComponent {
     { label: 'Kiwi', isDisabled: true },
   ];
 
+  selectedTabIndex = 1;
+
+  tabsValueOnChange(value: number): void {
+    console.log('New tab index:', value);
+    this.selectedTabIndex = value;
+  }
+
   stepperStates: StepStates = {
     '1': { isCompleted: true, heading: 'Title #1' },
     '2': { heading: 'Title #2' },

--- a/packages/web/src/app/doc-pages/components/tabs-doc/tabs-doc.component.html
+++ b/packages/web/src/app/doc-pages/components/tabs-doc/tabs-doc.component.html
@@ -19,60 +19,56 @@
   <app-component-section accessibility [sectionTitle]="'Accessibility'">
     <app-component-subsection [sectionTitle]="'Keyboard navigation'">
       <div class="accessibility-keyboard-navigation">
-        <div>
-          <span class="keyboard-button">Space</span>
+        <p class="e-m-0">
+          <kbd>Space</kbd>
           or
-          <span class="keyboard-button">Enter</span>
+          <kbd>Enter</kbd>
           to select the tab if you have
-          <span class="code-text">hasManualActivation</span>
-          set to true.
-        </div>
-        <div>
-          <span class="keyboard-button icon">
+          <code>hasManualActivation</code>
+          set to <code>true</code>.
+        </p>
+        <p class="e-m-0">
+          <kbd class="icon">
             <e-icon name="arrowLeft" size="xs" />
-          </span>
-          <span class="keyboard-button icon" style="margin-left: 0px">
+          </kbd>
+          <kbd class="icon e-ml-0">
             <e-icon name="arrowRight" size="xs" />
-          </span>
+          </kbd>
           to navigate through the tabs. Will also select the tab if
-          <span class="code-text">hasManualActivation</span>
-          is set to false, which is the default behavior.
-        </div>
+          <code>hasManualActivation</code>
+          is set to <code>false</code>, which is the default behavior.
+        </p>
       </div>
     </app-component-subsection>
-    <app-component-subsection [sectionTitle]="'ARIA'">
-      <ul class="e-list">
+    <app-component-subsection sectionTitle="ARIA">
+      <ol class="e-list e-list--numbers">
         <li>
           <strong>Role:</strong>
-          Add
-          <span class="code-text">role="tabpanel"</span>
-          to the corresponding content
-          <span class="code-text">closeAriaLabel</span>
-          to specify for assistive tools what the accordion is showing and hiding.
+          <p>
+            Add <code>role="tabpanel"</code> to each tabpanel (the element that contains the content
+            associated with a tab).
+          </p>
         </li>
         <li>
-          <strong>Aria labelledby:</strong>
-          Add
-          <span class="code-text">aria-labelledby='ewc-tabs-0'</span>
-          to the corresponding contents, with the id of that tab. The id of the tab is named like this:
-          <span class="code-text">'ewc-tabs-' + index</span>
-          . NB! If you have multiple set of tabs you should use the
-          <code>tabIdPrefix</code>
-          and the id will then be
-          <code>'ewc-tabs-prefix-index'</code>
-          e.g:
-          <code>'ewc-tabs-fruits-3'</code>
-          .
+          <strong>aria-labelledby:</strong>
+          <p>Add <code>aria-labelledby="ewc-tabs-[index]"</code> to each tabpanel.</p>
         </li>
         <li>
-          <strong>Aria controls:</strong>
-          The aria panels should also have unique id, which should correspond to the tabs aria-controls. The
-          aria-controls are named in the same way that the ids for the tabs are named, so it should be easy to
-          add the ids to panels e.g.
-          <code>id='ewc-tabs-fruits-3'</code>
-          .
+          <strong>aria-controls:</strong>
+          <p>Add <code>id="ewc-tabpanel-[index]"</code> to each tabpanel.</p>
         </li>
-      </ul>
+      </ol>
+      <div class="e-alert e-alert--info" role="note">
+        <div class="e-alert__icon">
+          <e-icon name="informationCircle" />
+        </div>
+        <p class="e-alert__text">
+          Use the <code>tabIdPrefix</code> prop to avoid ID collisions when using multiple tab groups. IDs
+          become <code>ewc-tabs-[prefix]-[index]</code> and <code>ewc-tabpanel-[prefix]-[index]</code>. e.g.,
+          <code>tabIdPrefix="fruits"</code> gives <code>ewc-tabs-fruits-0</code> &amp;
+          <code>ewc-tabpanel-fruits-0</code>.
+        </p>
+      </div>
     </app-component-subsection>
   </app-component-section>
 </app-component-documentation>


### PR DESCRIPTION
# PR Checklist
https://elvia.atlassian.net/wiki/spaces/TEAMATOM/pages/10427498683/Review+prosess

- [x] Bumpet package?
- [x] Updated changelog?
- [x] Correct date in changelog?

## Describe PR briefly:
In this PR, I set the `aria-controls`-attribute on each tab to `"ewc-tabpabel-[INDEX]"` to ensure that users can set the same value as the `id` on their tabpanel.

I also updated the a11y docs for the tabs, as the previous version had typos and was hard to understand.

See https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
